### PR TITLE
feat!:remove key swizzling and ignoring case by default

### DIFF
--- a/goschtalt.go
+++ b/goschtalt.go
@@ -91,7 +91,6 @@ func (c *Config) With(opts ...Option) error {
 	// These options must always be present to prevent panics, etc.
 	full := []Option{
 		SortRecordsNaturally(),
-		AlterKeyCase(nil),
 		SetKeyDelimiter("."),
 	}
 
@@ -211,9 +210,7 @@ func (c *Config) compile() error { //nolint:funlen
 			fmt.Fprintf(&c.explainCompile, "Error: %s\n", err)
 			return err
 		}
-		var err error
-		subtree := cfg.tree.AlterKeyCase(c.opts.keySwizzler)
-		merged, err = merged.Merge(subtree)
+		merged, err = merged.Merge(cfg.tree)
 		if err != nil {
 			fmt.Fprintf(&c.explainCompile, "Error: %s\n", err)
 			return err

--- a/goschtalt_test.go
+++ b/goschtalt_test.go
@@ -6,7 +6,6 @@ package goschtalt
 import (
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -30,7 +29,7 @@ func TestNew(t *testing.T) {
 			description: "A normal case with no options.",
 		}, {
 			description: "A normal case with options.",
-			opts:        []Option{AlterKeyCase(strings.ToLower), AutoCompile()},
+			opts:        []Option{AutoCompile()},
 		}, {
 			description: "A case with an empty option.",
 			opts:        []Option{zeroOpt},
@@ -73,21 +72,21 @@ func TestCompile(t *testing.T) {
 			Mode: 0755,
 		},
 		"3.json": &fstest.MapFile{
-			Data: []byte(`{"hello":"Mr. Blue Sky"}`),
+			Data: []byte(`{"Hello":"Mr. Blue Sky"}`),
 			Mode: 0755,
 		},
 	}
 
 	fs2 := fstest.MapFS{
 		"b/90.json": &fstest.MapFile{
-			Data: []byte(`{"madd": "cat", "blue": "${thing}"}`),
+			Data: []byte(`{"Madd": "cat", "Blue": "${thing}"}`),
 			Mode: 0755,
 		},
 	}
 
 	fs3 := fstest.MapFS{
 		"b/90.json": &fstest.MapFile{
-			Data: []byte(`{"Hello((fail))": "cat", "blue": "bird"}`),
+			Data: []byte(`{"Hello((fail))": "cat", "Blue": "bird"}`),
 			Mode: 0755,
 		},
 	}
@@ -156,7 +155,6 @@ func TestCompile(t *testing.T) {
 		{
 			description: "A normal case with options.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddTree(fs1, "."),
 				AddTree(fs2, "."),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
@@ -172,7 +170,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A normal case with an encoded buffer.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddBuffer("1.json", []byte(`{"Hello": "Mr. Blue Sky"}`)),
 				AddBuffer("2.json", []byte(`{"Blue": "${thing}"}`)),
 				AddBuffer("3.json", []byte(`{"Madd": "cat"}`)),
@@ -189,7 +186,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A normal case with an encoded buffer function.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddBuffer("3.json", []byte(`{"Madd": "cat"}`)),
 				AddBuffer("2.json", []byte(`{"Blue": "${thing}"}`)),
 				AddBufferFn("1.json", func(_ string, _ UnmarshalFunc) ([]byte, error) {
@@ -208,17 +204,16 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A case with an encoded buffer function that looks up something from the tree.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddBuffer("1.json", []byte(`{"Madd": "cat"}`)),
 				AddBufferFn("2.json", func(_ string, un UnmarshalFunc) ([]byte, error) {
 					var s string
-					_ = un("madd", &s)
-					return []byte(fmt.Sprintf(`{"blue": "%s"}`, s)), nil
+					_ = un("Madd", &s)
+					return []byte(fmt.Sprintf(`{"Blue": "%s"}`, s)), nil
 				}),
 				AddBufferFn("3.json", func(_ string, un UnmarshalFunc) ([]byte, error) {
 					var s string
-					_ = un("blue", &s)
-					return []byte(fmt.Sprintf(`{"hello": "%s"}`, s)), nil
+					_ = un("Blue", &s)
+					return []byte(fmt.Sprintf(`{"Hello": "%s"}`, s)), nil
 				}),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
 				AutoCompile(),
@@ -234,7 +229,6 @@ func TestCompile(t *testing.T) {
 			description:   "A case with an encoded buffer that is invalid",
 			compileOption: true,
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
 				AutoCompile(),
 				AddBuffer("1.json", []byte(`invalid`)),
@@ -244,7 +238,6 @@ func TestCompile(t *testing.T) {
 			description:   "An encoded buffer can't be decoded.",
 			compileOption: true,
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AutoCompile(),
 				AddBuffer("1.json", []byte(`invalid`)),
 			},
@@ -253,7 +246,6 @@ func TestCompile(t *testing.T) {
 			description:   "An encoded buffer with an option that causes a failure.",
 			compileOption: true,
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
 				AutoCompile(),
 				AddBuffer("1.json", []byte(`{}`), WithError(testErr)),
@@ -263,7 +255,6 @@ func TestCompile(t *testing.T) {
 			description:   "A case with an encoded buffer fn that returns an error",
 			compileOption: true,
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
 				AutoCompile(),
 				AddBufferFn("3.json", func(_ string, _ UnmarshalFunc) ([]byte, error) {
@@ -275,7 +266,6 @@ func TestCompile(t *testing.T) {
 			description:   "A case with an encoded buffer fn that returns an invalidly formatted buffer",
 			compileOption: true,
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
 				AutoCompile(),
 				AddBufferFn("3.json", func(_ string, _ UnmarshalFunc) ([]byte, error) {
@@ -286,7 +276,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A normal case with options including expansion.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddTree(fs1, "."),
 				AddTree(fs2, "."),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
@@ -303,7 +292,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A normal case with values.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddValue("record1", Root, st1{
 					Hello: "Mr. Blue Sky",
 					Blue:  "jay",
@@ -320,7 +308,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A normal case with non-serializable values being errors.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddValue("record1", Root,
 					st1{
 						Hello: "Mr. Blue Sky",
@@ -339,7 +326,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A normal case with non-serializable values being dropped.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddValue("record1", Root,
 					st2{
 						Hello: "Mr. Blue Sky",
@@ -357,7 +343,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "An empty case.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
 			},
 			want:   st1{},
@@ -365,7 +350,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "An empty set of files.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddFiles(fs1),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
 			},
@@ -374,7 +358,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A merge failure case.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddTree(fs1, "."),
 				AddTree(fs3, "."),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
@@ -385,7 +368,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A decode failure case.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddTree(fs1, "."),
 				AddTree(fs4, "."),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
@@ -396,7 +378,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A recursion case where a failure results",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddTree(fs1, "."),
 				AddTree(fs2, "."),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
@@ -410,7 +391,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A case where the value decoder errors",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddValue("record1", Root, st1{
 					Hello: "Mr. Blue Sky",
 					Blue:  "jay",
@@ -423,7 +403,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A case where the value doesn't have a record name.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AutoCompile(),
 				AddValue("", Root, st1{
 					Hello: "Mr. Blue Sky",
@@ -438,7 +417,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A case where the value function returns an error.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AutoCompile(),
 				AddValueFn("record", Root,
 					func(string, UnmarshalFunc) (any, error) {
@@ -453,7 +431,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A case where the decode hook is invalid.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddValue("record", Root, st1{
 					Hello: "Mr. Blue Sky",
 					Blue:  "jay",
@@ -466,7 +443,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A case where the an option is/becomes an error.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddValue("record", Root, st1{
 					Hello: "Mr. Blue Sky",
 					Blue:  "jay",
@@ -484,7 +460,6 @@ func TestCompile(t *testing.T) {
 		}, {
 			description: "A case with non-serializable values producing an error.",
 			opts: []Option{
-				AlterKeyCase(strings.ToLower),
 				AddValue("record1", Root,
 					st2{
 						Hello: "Mr. Blue Sky",

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -5,7 +5,6 @@ package goschtalt
 
 import (
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -95,7 +94,6 @@ func TestMarshal(t *testing.T) {
 				compiledAt: now,
 				opts: options{
 					encoders:     newRegistry[encoder.Encoder](),
-					keySwizzler:  strings.ToLower,
 					keyDelimiter: ".",
 				},
 			}

--- a/options.go
+++ b/options.go
@@ -42,7 +42,6 @@ type options struct {
 	// Settings where there are one.
 	autoCompile  bool
 	keyDelimiter string
-	keySwizzler  func(string) string
 	sorter       func(a, b string) bool
 
 	// Codecs where there can be many.
@@ -272,45 +271,6 @@ func (a autoCompileOption) apply(opts *options) error {
 func (_ autoCompileOption) ignoreDefaults() bool { return false }
 func (a autoCompileOption) String() string {
 	return print.P("AutoCompile", print.BoolSilentTrue(bool(a)))
-}
-
-// AlterKeyCase defines how the keys should be altered prior to use.  This
-// option enables enforcing key case to be all upper case, all lower case,
-// no change or whatever is needed.
-//
-// Passing nil alter value is interpreted as "do not alter" the key case and
-// is the same as passing:
-//
-//	func(s string) string { return s }
-//
-// Examples:
-//
-//	AlterKeyCase(strings.ToLower)
-//	AlterKeyCase(strings.ToUpper)
-//
-// # Default
-//
-// AlterKeyCase is set to "do not alter".
-func AlterKeyCase(alter func(string) string) Option {
-	return alterKeyCaseOption(alter)
-}
-
-type alterKeyCaseOption func(string) string
-
-func (alter alterKeyCaseOption) apply(opts *options) error {
-	if alter == nil {
-		alter = func(s string) string { return s }
-	}
-	opts.keySwizzler = alter
-	return nil
-}
-
-func (_ alterKeyCaseOption) ignoreDefaults() bool {
-	return false
-}
-
-func (a alterKeyCaseOption) String() string {
-	return print.P("AlterKeyCase", print.FnAltNil(a, "none"))
 }
 
 // SetKeyDelimiter provides the delimiter used for determining key parts.  A

--- a/options_test.go
+++ b/options_test.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
-	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -221,36 +220,6 @@ func TestOptions(t *testing.T) {
 			description: "AutoCompile(false)",
 			opt:         AutoCompile(false),
 			str:         "AutoCompile( false )",
-		}, {
-			description: "AlterKeyCase(nil)",
-			opt:         AlterKeyCase(nil),
-			str:         "AlterKeyCase( none )",
-			check: func(cfg *options) bool {
-				if cfg.keySwizzler == nil {
-					return false
-				}
-				return cfg.keySwizzler("AbCd") == "AbCd"
-			},
-		}, {
-			description: "AlterKeyCase(strings.ToLower)",
-			opt:         AlterKeyCase(strings.ToLower),
-			str:         "AlterKeyCase( custom )",
-			check: func(cfg *options) bool {
-				if cfg.keySwizzler == nil {
-					return false
-				}
-				return cfg.keySwizzler("AbCd") == "abcd"
-			},
-		}, {
-			description: "AlterKeyCase(strings.ToUpper)",
-			opt:         AlterKeyCase(strings.ToUpper),
-			str:         "AlterKeyCase( custom )",
-			check: func(cfg *options) bool {
-				if cfg.keySwizzler == nil {
-					return false
-				}
-				return cfg.keySwizzler("AbCd") == "ABCD"
-			},
 		}, {
 			description: "SetKeyDelimiter( . )",
 			opt:         SetKeyDelimiter("."),

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -94,8 +94,12 @@ func (c *Config) Unmarshal(key string, result any, opts ...UnmarshalOption) erro
 }
 
 func (c *Config) unmarshal(key string, result any, tree meta.Object, opts ...UnmarshalOption) error {
-	var options unmarshalOptions
-	options.decoder.Result = result
+	options := unmarshalOptions{
+		decoder: mapstructure.DecoderConfig{
+			Result:    result,
+			MatchName: func(a, b string) bool { return a == b },
+		},
+	}
 
 	full := append(c.opts.unmarshalOptions, opts...)
 	for _, opt := range full {
@@ -109,7 +113,6 @@ func (c *Config) unmarshal(key string, result any, tree meta.Object, opts ...Unm
 
 	obj := tree
 	if len(key) > 0 {
-		key = c.opts.keySwizzler(key)
 		path := strings.Split(key, c.opts.keyDelimiter)
 
 		var err error

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -52,7 +52,7 @@ func TestUnmarshal(t *testing.T) {
 	}{
 		{
 			description: "A simple tree.",
-			input:       `{"foo":"bar", "delta": "1s"}`,
+			input:       `{"Foo":"bar", "Delta": "1s"}`,
 			opts:        []UnmarshalOption{},
 			want:        simple{},
 			expected: simple{
@@ -61,19 +61,19 @@ func TestUnmarshal(t *testing.T) {
 			},
 		}, {
 			description: "A simple tree showing the duration doesn't decode.",
-			input:       `{"foo":"bar", "delta": "1s"}`,
+			input:       `{"Foo":"bar", "Delta": "1s"}`,
 			opts:        []UnmarshalOption{},
 			want:        withDuration{},
 			expectedErr: unknownErr,
 		}, {
 			description: "A simple tree showing the duration doesn't decode, with zero option.",
-			input:       `{"foo":"bar", "delta": "1s"}`,
+			input:       `{"Foo":"bar", "Delta": "1s"}`,
 			opts:        []UnmarshalOption{zeroOpt},
 			want:        withDuration{},
 			expectedErr: unknownErr,
 		}, {
 			description: "A simple tree with the DecodeHook() behavior works with duration hook.",
-			input:       `{"foo":"bar", "delta": "1s"}`,
+			input:       `{"Foo":"bar", "Delta": "1s"}`,
 			opts: []UnmarshalOption{
 				DecodeHook(
 					mapstructure.ComposeDecodeHookFunc(
@@ -85,7 +85,7 @@ func TestUnmarshal(t *testing.T) {
 			},
 		}, {
 			description: "Verify the ErrorUnused() behavior succeeds.",
-			input:       `{"foo":"bar", "delta": "1s"}`,
+			input:       `{"Foo":"bar", "Delta": "1s"}`,
 			opts:        []UnmarshalOption{ErrorUnused(true)},
 			want:        simple{},
 			expected: simple{
@@ -94,13 +94,13 @@ func TestUnmarshal(t *testing.T) {
 			},
 		}, {
 			description: "Verify the ErrorUnused behavior fails.",
-			input:       `{"foo":"bar", "delta": "1s", "extra": "arg"}`,
+			input:       `{"Foo":"bar", "Delta": "1s", "extra": "arg"}`,
 			opts:        []UnmarshalOption{ErrorUnused(true)},
 			want:        simple{},
 			expectedErr: unknownErr,
 		}, {
 			description: "Verify the ErrorUnset() behavior succeeds.",
-			input:       `{"foo":"bar", "delta": "1s"}`,
+			input:       `{"Foo":"bar", "Delta": "1s"}`,
 			opts:        []UnmarshalOption{ErrorUnset(true)},
 			want:        simple{},
 			expected: simple{
@@ -109,13 +109,13 @@ func TestUnmarshal(t *testing.T) {
 			},
 		}, {
 			description: "Verify the ErrorUnset() behavior fails.",
-			input:       `{"foo":"bar", "extra": "arg"}`,
+			input:       `{"Foo":"bar", "extra": "arg"}`,
 			opts:        []UnmarshalOption{ErrorUnset(true)},
 			want:        simple{},
 			expectedErr: unknownErr,
 		}, {
 			description: "Verify the WeaklyTypedInput() behavior succeeds.",
-			input:       `{"foo":"bar", "bool": "T"}`,
+			input:       `{"Foo":"bar", "Bool": "T"}`,
 			opts:        []UnmarshalOption{WeaklyTypedInput(true)},
 			want:        withBool{},
 			expected: withBool{
@@ -148,7 +148,7 @@ func TestUnmarshal(t *testing.T) {
 			},
 		}, {
 			description: "Verify the WithValidator(fn) behavior works.",
-			input:       `{"foo":"bar"}`,
+			input:       `{"Foo":"bar"}`,
 			opts:        []UnmarshalOption{WithValidator(func(any) error { return nil })},
 			want:        simple{},
 			expected: simple{
@@ -156,7 +156,7 @@ func TestUnmarshal(t *testing.T) {
 			},
 		}, {
 			description: "Verify the WithValidator(nil) behavior works.",
-			input:       `{"foo":"bar"}`,
+			input:       `{"Foo":"bar"}`,
 			opts: []UnmarshalOption{
 				WithValidator(func(any) error { return unknownErr }),
 				WithValidator(nil),
@@ -167,7 +167,7 @@ func TestUnmarshal(t *testing.T) {
 			},
 		}, {
 			description: "Verify the WithValidator(fn) failure mode works.",
-			input:       `{"foo":"bar"}`,
+			input:       `{"Foo":"bar"}`,
 			opts: []UnmarshalOption{
 				WithValidator(func(any) error { return unknownErr }),
 			},
@@ -175,7 +175,7 @@ func TestUnmarshal(t *testing.T) {
 			expectedErr: unknownErr,
 		}, {
 			description: "Verify handling an error option.",
-			input:       `{"foo":"bar"}`,
+			input:       `{"Foo":"bar"}`,
 			opts: []UnmarshalOption{
 				WithError(testErr),
 			},
@@ -183,32 +183,32 @@ func TestUnmarshal(t *testing.T) {
 			expectedErr: testErr,
 		}, {
 			description: "A struct that wasn't compiled.",
-			input:       `{"foo":"bar", "delta": "1s"}`,
+			input:       `{"Foo":"bar", "Delta": "1s"}`,
 			notCompiled: true,
 			opts:        []UnmarshalOption{},
 			want:        simple{},
 			expectedErr: ErrNotCompiled,
 		}, {
 			description: "A nil result value.",
-			input:       `{"foo":"bar", "delta": "1s"}`,
+			input:       `{"Foo":"bar", "Delta": "1s"}`,
 			nilWanted:   true,
 			opts:        []UnmarshalOption{},
 			expectedErr: unknownErr,
 		}, {
 			description: "Make sure that indexing an array works",
-			key:         "foo.0",
-			input:       `{"foo":["one", "two"]}`,
+			key:         "Foo.0",
+			input:       `{"Foo":["one", "two"]}`,
 			opts:        []UnmarshalOption{Required()},
 			want:        "",
 			expected:    "one",
 		}, {
 			description: "Make sure that indexing an array is a number or error",
-			key:         "foo.bar",
-			input:       `{"foo":[{"foo":"one"}, "two"]}`,
+			key:         "Foo.Bar",
+			input:       `{"Foo":[{"Foo":"one"}, "two"]}`,
 			expectedErr: unknownErr,
 		}, {
 			description: "Verify the AddDefaultUnmarshalOption() works.",
-			input:       `{"foo":"bar", "bool": "T"}`,
+			input:       `{"Foo":"bar", "Bool": "T"}`,
 			defOpts:     []Option{DefaultUnmarshalOptions(WeaklyTypedInput(true))},
 			want:        withBool{},
 			expected: withBool{
@@ -234,7 +234,6 @@ func TestUnmarshal(t *testing.T) {
 				tree:       tree,
 				compiledAt: now,
 				opts: options{
-					keySwizzler:  strings.ToLower,
 					keyDelimiter: ".",
 				},
 			}
@@ -304,7 +303,7 @@ func TestUnmarshalFn(t *testing.T) {
 					Map: map[string]meta.Object{
 						"test": {
 							Map: map[string]meta.Object{
-								"foo": {
+								"Foo": {
 									Value: "bar",
 								},
 							},

--- a/unmarshalvalue.go
+++ b/unmarshalvalue.go
@@ -203,7 +203,7 @@ func (val ignoreUntaggedFieldsOption) String() string {
 //
 // # Default
 //
-// MatchName is nil.
+// MatchName is configured to exactly match.
 func MatchName(fn func(key, field string) bool) UnmarshalValueOption {
 	return &matchNameOption{fn: fn}
 }


### PR DESCRIPTION
BREAKING CHANGE: Removes AlterKeyCase() and changes the default behavior for MatchName() to be exact match vs. ignoring character case.

Why change to be more strict?  There are a number of complexities that arise from trying to merge keys of a structure.  For example, one key could define processing instructions and a conflicting key could have no processing instructions.  In this case it is unclear what goschtalt should do.  Hence, it is better to remove the uncertainty in favor of strictness.