### PR TITLE
feat!:Improve the names.

### DIFF
--- a/expand.go
+++ b/expand.go
@@ -74,7 +74,7 @@ func Expand(mapper func(string) string, opts ...ExpandOption) Option {
 	}
 
 	exp.text = print.P("Expand",
-		print.Fn(mapper),
+		print.Func(mapper),
 		print.Literal("..."),
 		print.Yields(
 			print.String(exp.start, "start"),

--- a/expand_test.go
+++ b/expand_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestExpand(t *testing.T) {
 	testErr := errors.New("test error")
-	fn := func(_ string) string {
+	expander := func(_ string) string {
 		return ""
 	}
 	tests := []struct {
@@ -22,12 +22,12 @@ func TestExpand(t *testing.T) {
 		in          Option
 		want        expand
 		count       int
-		fnNil       bool
+		nilFunc     bool
 		expectErr   error
 	}{
 		{
 			description: "Simple success",
-			in:          Expand(fn),
+			in:          Expand(expander),
 			str:         "Expand( custom, ... ) --> start: '${', end: '}', origin: '', maximum: 0",
 			count:       1,
 			want: expand{
@@ -41,7 +41,7 @@ func TestExpand(t *testing.T) {
 			str:         "Expand( nil, ... ) --> start: '${', end: '}', origin: '', maximum: 0",
 		}, {
 			description: "Fully defined",
-			in:          Expand(fn, WithOrigin("origin"), WithDelimiters("${{", "}}"), WithMaximum(10)),
+			in:          Expand(expander, WithOrigin("origin"), WithDelimiters("${{", "}}"), WithMaximum(10)),
 			str:         "Expand( custom, ... ) --> start: '${{', end: '}}', origin: 'origin', maximum: 10",
 			count:       1,
 			want: expand{
@@ -90,7 +90,7 @@ func TestExpand(t *testing.T) {
 
 				assert.Equal(tc.count, len(c.opts.expansions))
 				if tc.count == 1 {
-					if tc.fnNil {
+					if tc.nilFunc {
 						assert.Nil(c.opts.expansions[0].mapper)
 					}
 					c.opts.expansions[0].mapper = nil

--- a/goschtalt.go
+++ b/goschtalt.go
@@ -205,12 +205,12 @@ func (c *Config) compile() error { //nolint:funlen
 				return err
 			}
 		}
-		unmarshalFn := func(key string, result any, opts ...UnmarshalOption) error {
+		unmarshalFunc := func(key string, result any, opts ...UnmarshalOption) error {
 			// Pass in the merged value from this context and stage of processing.
 			return c.unmarshal(key, result, incremental, opts...)
 		}
 
-		if err = cfg.fetch(c.opts.keyDelimiter, unmarshalFn, c.opts.decoders, c.opts.valueOptions); err != nil {
+		if err = cfg.fetch(c.opts.keyDelimiter, unmarshalFunc, c.opts.decoders, c.opts.valueOptions); err != nil {
 			fmt.Fprintf(&c.explainCompile, "Error: %s\n", err)
 			return err
 		}

--- a/goschtalt_test.go
+++ b/goschtalt_test.go
@@ -204,7 +204,7 @@ func TestCompile(t *testing.T) {
 			opts: []Option{
 				AddBuffer("3.json", []byte(`{"Madd": "cat"}`)),
 				AddBuffer("2.json", []byte(`{"Blue": "${thing}"}`)),
-				AddBufferFn("1.json", func(_ string, _ UnmarshalFunc) ([]byte, error) {
+				AddBufferFunc("1.json", func(_ string, _ Unmarshaller) ([]byte, error) {
 					return []byte(`{"Hello": "Mr. Blue Sky"}`), nil
 				}),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
@@ -221,12 +221,12 @@ func TestCompile(t *testing.T) {
 			description: "A case with an encoded buffer function that looks up something from the tree.",
 			opts: []Option{
 				AddBuffer("1.json", []byte(`{"Madd": "cat"}`)),
-				AddBufferFn("2.json", func(_ string, un UnmarshalFunc) ([]byte, error) {
+				AddBufferFunc("2.json", func(_ string, un Unmarshaller) ([]byte, error) {
 					var s string
 					_ = un("Madd", &s)
 					return []byte(fmt.Sprintf(`{"Blue": "%s"}`, s)), nil
 				}),
-				AddBufferFn("3.json", func(_ string, un UnmarshalFunc) ([]byte, error) {
+				AddBufferFunc("3.json", func(_ string, un Unmarshaller) ([]byte, error) {
 					var s string
 					_ = un("Blue", &s)
 					return []byte(fmt.Sprintf(`{"Hello": "%s"}`, s)), nil
@@ -268,23 +268,23 @@ func TestCompile(t *testing.T) {
 			},
 			expectedErr: testErr,
 		}, {
-			description:   "A case with an encoded buffer fn that returns an error",
+			description:   "A case with an encoded buffer function that returns an error",
 			compileOption: true,
 			opts: []Option{
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
 				AutoCompile(),
-				AddBufferFn("3.json", func(_ string, _ UnmarshalFunc) ([]byte, error) {
+				AddBufferFunc("3.json", func(_ string, _ Unmarshaller) ([]byte, error) {
 					return nil, unknownErr
 				}),
 			},
 			expectedErr: unknownErr,
 		}, {
-			description:   "A case with an encoded buffer fn that returns an invalidly formatted buffer",
+			description:   "A case with an encoded buffer function that returns an invalidly formatted buffer",
 			compileOption: true,
 			opts: []Option{
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
 				AutoCompile(),
-				AddBufferFn("3.json", func(_ string, _ UnmarshalFunc) ([]byte, error) {
+				AddBufferFunc("3.json", func(_ string, _ Unmarshaller) ([]byte, error) {
 					return []byte(`invalid`), nil
 				}),
 			},
@@ -342,12 +342,12 @@ func TestCompile(t *testing.T) {
 					Blue:  "jay",
 					Madd:  "cat",
 				},
-					KeymapFn(func(s string) string {
+					KeymapFunc(func(s string) string {
 						return strings.ToLower(s)
 					}),
 				),
 				DefaultUnmarshalOptions(
-					KeymapFn(func(s string) string {
+					KeymapFunc(func(s string) string {
 						return strings.ToLower(s)
 					}),
 				),
@@ -528,8 +528,8 @@ func TestCompile(t *testing.T) {
 			description: "A case where the value function returns an error.",
 			opts: []Option{
 				AutoCompile(),
-				AddValueFn("record", Root,
-					func(string, UnmarshalFunc) (any, error) {
+				AddValueFunc("record", Root,
+					func(string, Unmarshaller) (any, error) {
 						return nil, testErr
 					},
 				),

--- a/internal/print/print.go
+++ b/internal/print/print.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	nilFnName    = "nil"
+	nilFuncName  = "nil"
 	nilBytesName = "nil"
 	nilErrorName = "nil"
 
-	notNilFnName    = "custom"
+	notNilFuncName  = "custom"
 	notNilBytesName = "[]byte"
 )
 
@@ -139,37 +139,37 @@ func Error(e error, label ...string) Option {
 	return labeledSimpleOption(txt, label...)
 }
 
-// isFnNil is a helper function for determining if a function is nil.
-// Comparing the fn via an interface can't be done with just a comparison to
+// isFuncNil is a helper function for determining if a function is nil.
+// Comparing the f via an interface can't be done with just a comparison to
 // nil.  The inner value of the func must be checked if the outer interface
 // is not nil.
-func isFnNil(fn any) bool {
-	return fn == nil || reflect.ValueOf(fn).IsNil()
+func isFuncNil(f any) bool {
+	return f == nil || reflect.ValueOf(f).IsNil()
 }
 
-// Fn takes a func with optional label and renders them consistently.
-func Fn(fn any, label ...string) Option {
-	txt := nilFnName
-	if !isFnNil(fn) {
-		txt = notNilFnName
+// Func takes a func with optional label and renders them consistently.
+func Func(f any, label ...string) Option {
+	txt := nilFuncName
+	if !isFuncNil(f) {
+		txt = notNilFuncName
 	}
 	return labeledSimpleOption(txt, label...)
 }
 
-// FnAltNil renders the function like Fn() except the alt string is used for when
+// FuncAltNil renders the function like Func() except the alt string is used for when
 // the function is nil.
-func FnAltNil(fn any, alt string, label ...string) Option {
-	if !isFnNil(fn) {
-		alt = notNilFnName
+func FuncAltNil(f any, alt string, label ...string) Option {
+	if !isFuncNil(f) {
+		alt = notNilFuncName
 	}
 	return labeledSimpleOption(alt, label...)
 }
 
-// FnAltNotNil renders the function like Fn() except the alt string is used for
+// FuncAltNotNil renders the function like Func() except the alt string is used for
 // when the function is not nil.
-func FnAltNotNil(fn any, alt string, label ...string) Option {
-	if isFnNil(fn) {
-		alt = nilFnName
+func FuncAltNotNil(f any, alt string, label ...string) Option {
+	if isFuncNil(f) {
+		alt = nilFuncName
 	}
 	return labeledSimpleOption(alt, label...)
 }

--- a/internal/print/print_test.go
+++ b/internal/print/print_test.go
@@ -84,40 +84,40 @@ func TestP(t *testing.T) {
 			opt:    Error(errors.New("test"), "label"),
 			expect: "Foo( label: 'test' )",
 		}, {
-			opt:    Fn(nil),
+			opt:    Func(nil),
 			expect: "Foo( nil )",
 		}, {
-			opt:    Fn(nil, "label"),
+			opt:    Func(nil, "label"),
 			expect: "Foo( label: nil )",
 		}, {
-			opt:    Fn(func() {}),
+			opt:    Func(func() {}),
 			expect: "Foo( custom )",
 		}, {
-			opt:    Fn(func() {}, "label"),
+			opt:    Func(func() {}, "label"),
 			expect: "Foo( label: custom )",
 		}, {
-			opt:    FnAltNil(nil, "empty"),
+			opt:    FuncAltNil(nil, "empty"),
 			expect: "Foo( empty )",
 		}, {
-			opt:    FnAltNil(nil, "empty", "label"),
+			opt:    FuncAltNil(nil, "empty", "label"),
 			expect: "Foo( label: empty )",
 		}, {
-			opt:    FnAltNil(func() {}, "empty"),
+			opt:    FuncAltNil(func() {}, "empty"),
 			expect: "Foo( custom )",
 		}, {
-			opt:    FnAltNil(func() {}, "empty", "label"),
+			opt:    FuncAltNil(func() {}, "empty", "label"),
 			expect: "Foo( label: custom )",
 		}, {
-			opt:    FnAltNotNil(nil, "something"),
+			opt:    FuncAltNotNil(nil, "something"),
 			expect: "Foo( nil )",
 		}, {
-			opt:    FnAltNotNil(nil, "something", "label"),
+			opt:    FuncAltNotNil(nil, "something", "label"),
 			expect: "Foo( label: nil )",
 		}, {
-			opt:    FnAltNotNil(func() {}, "something"),
+			opt:    FuncAltNotNil(func() {}, "something"),
 			expect: "Foo( something )",
 		}, {
-			opt:    FnAltNotNil(func() {}, "something", "label"),
+			opt:    FuncAltNotNil(func() {}, "something", "label"),
 			expect: "Foo( label: something )",
 		}, {
 			opt:    Int(5),
@@ -191,20 +191,20 @@ func TestP(t *testing.T) {
 			expect: "Foo( label: map[1] )",
 		}, {
 			opts: []Option{
-				Bool(true), Fn(nil, "label"), Literal("abs"),
+				Bool(true), Func(nil, "label"), Literal("abs"),
 			},
 			expect: "Foo( true, label: nil, abs )",
 		}, {
 			opts: []Option{
-				Bool(true), nil, Fn(nil, "label"), Literal("abs"),
+				Bool(true), nil, Func(nil, "label"), Literal("abs"),
 				Yields(
-					Bool(true, "a"), nil, Fn(nil, "b"), Literal("abs", "c"),
+					Bool(true, "a"), nil, Func(nil, "b"), Literal("abs", "c"),
 				),
 			},
 			expect: "Foo( true, label: nil, abs ) --> a: true, b: nil, c: abs",
 		}, {
 			opts: []Option{
-				Bool(true, "label"), Fn(nil), Literal("abs"), SubOpt(),
+				Bool(true, "label"), Func(nil), Literal("abs"), SubOpt(),
 			},
 			expect: "Foo(label: true, nil, abs)",
 		},

--- a/options.go
+++ b/options.go
@@ -302,7 +302,7 @@ func (s setKeyDelimiterOption) String() string {
 	return print.P("SetKeyDelimiter", print.String(string(s)))
 }
 
-// SortRecordsCustomFn provides a way to specify how you want the files sorted
+// SortRecordsCustomFunc provides a way to specify how you want the files sorted
 // prior to their merge.  This function provides a way to provide a completely
 // custom sorting algorithm.
 //
@@ -311,24 +311,24 @@ func (s setKeyDelimiterOption) String() string {
 // # Default
 //
 // The default is [SortRecordsNaturally].
-func SortRecordsCustomFn(less func(a, b string) bool) Option {
-	return &sortRecordsCustomFnOption{
-		text: print.P("SortRecordsCustomFn", print.Fn(less)),
-		fn:   less,
+func SortRecordsCustomFunc(less func(a, b string) bool) Option {
+	return &sortRecordsCustomFuncOption{
+		text:   print.P("SortRecordsCustomFunc", print.Func(less)),
+		sorter: less,
 	}
 }
 
 // SortRecordsLexically provides a built in sorter based on lexical order.
 //
-// See also: [SortRecordsCustomFn], [SortRecordsNaturally]
+// See also: [SortRecordsCustomFunc], [SortRecordsNaturally]
 //
 // # Default
 //
 // The default is [SortRecordsNaturally].
 func SortRecordsLexically() Option {
-	return &sortRecordsCustomFnOption{
+	return &sortRecordsCustomFuncOption{
 		text: print.P("SortRecordsLexically"),
-		fn: func(a, b string) bool {
+		sorter: func(a, b string) bool {
 			return a < b
 		},
 	}
@@ -354,34 +354,34 @@ func SortRecordsLexically() Option {
 //	99_mine.yml
 //	100_alpha.yml
 //
-// See also: [SortRecordsCustomFn], [SortRecordsLexically]
+// See also: [SortRecordsCustomFunc], [SortRecordsLexically]
 //
 // # Default
 //
 // The default is [SortRecordsNaturally].
 func SortRecordsNaturally() Option {
-	return &sortRecordsCustomFnOption{
-		text: print.P("SortRecordsNaturally"),
-		fn:   natsort.Compare,
+	return &sortRecordsCustomFuncOption{
+		text:   print.P("SortRecordsNaturally"),
+		sorter: natsort.Compare,
 	}
 }
 
-type sortRecordsCustomFnOption struct {
-	text string
-	fn   func(a, b string) bool
+type sortRecordsCustomFuncOption struct {
+	text   string
+	sorter func(a, b string) bool
 }
 
-func (s sortRecordsCustomFnOption) apply(opts *options) error {
-	if s.fn == nil {
+func (s sortRecordsCustomFuncOption) apply(opts *options) error {
+	if s.sorter == nil {
 		return fmt.Errorf("%w: a SortRecords function/option must be specified", ErrInvalidInput)
 	}
 
-	opts.sorter = s.fn
+	opts.sorter = s.sorter
 	return nil
 }
 
-func (_ sortRecordsCustomFnOption) ignoreDefaults() bool { return false }
-func (s sortRecordsCustomFnOption) String() string       { return s.text }
+func (_ sortRecordsCustomFuncOption) ignoreDefaults() bool { return false }
+func (s sortRecordsCustomFuncOption) String() string       { return s.text }
 
 // WithDecoder registers a Decoder for the specific file extensions provided.
 // Attempting to register a duplicate extension is not supported.
@@ -521,7 +521,7 @@ func (d defaultUnmarshalOption) String() string {
 }
 
 // DefaultValueOptions allows customization of the desired options for all
-// invocations of the [AddValue]() and [AddValueFn]() functions.  This should
+// invocations of the [AddValue]() and [AddValueFunc]() functions.  This should
 // make consistent use use of these functions easier.
 //
 // Valid Option Types:

--- a/options_test.go
+++ b/options_test.go
@@ -31,7 +31,7 @@ func TestOptions(t *testing.T) {
 	list := []string{"zeta", "alpha", "19beta", "19alpha", "4tango",
 		"1alpha", "7alpha", "bravo", "7alpha10", "7alpha2", "7alpha0"}
 
-	retBuf := func(name string, un UnmarshalFunc) ([]byte, error) {
+	retBuf := func(name string, un Unmarshaller) ([]byte, error) {
 		return []byte(name), nil
 	}
 
@@ -234,16 +234,16 @@ func TestOptions(t *testing.T) {
 			str:         "SetKeyDelimiter( '' )",
 			expectErr:   ErrInvalidInput,
 		}, {
-			description: "SortRecordsCustomFn( nil )",
-			opt:         SortRecordsCustomFn(nil),
-			str:         "SortRecordsCustomFn( nil )",
+			description: "SortRecordsCustomFunc( nil )",
+			opt:         SortRecordsCustomFunc(nil),
+			str:         "SortRecordsCustomFunc( nil )",
 			expectErr:   ErrInvalidInput,
 		}, {
-			description: "SortRecordsCustomFn( '(reverse)' )",
-			opt: SortRecordsCustomFn(func(a, b string) bool {
+			description: "SortRecordsCustomFunc( '(reverse)' )",
+			opt: SortRecordsCustomFunc(func(a, b string) bool {
 				return a > b
 			}),
-			str: "SortRecordsCustomFn( custom )",
+			str: "SortRecordsCustomFunc( custom )",
 			check: func(cfg *options) bool {
 				return sortCheck(cfg, []string{
 					"zeta",
@@ -494,7 +494,7 @@ func TestOptions(t *testing.T) {
 			check: func(cfg *options) bool {
 				if len(cfg.values) == 1 {
 					if cfg.values[0].name == "filename.ext" {
-						if cfg.values[0].buf.fn != nil {
+						if cfg.values[0].buf.getter != nil {
 							return true
 						}
 					}
@@ -508,7 +508,7 @@ func TestOptions(t *testing.T) {
 			check: func(cfg *options) bool {
 				if len(cfg.values) == 1 {
 					if cfg.values[0].name == "filename.ext" {
-						if cfg.values[0].buf.fn != nil {
+						if cfg.values[0].buf.getter != nil {
 							return true
 						}
 					}
@@ -521,18 +521,18 @@ func TestOptions(t *testing.T) {
 			str:         "AddBuffer( '', []byte )",
 			expectErr:   unknown,
 		}, {
-			description: "AddBufferFn( filename.ext, nil )",
-			opt:         AddBufferFn("filename.ext", nil),
-			str:         "AddBufferFn( 'filename.ext', nil )",
+			description: "AddBufferFunc( filename.ext, nil )",
+			opt:         AddBufferFunc("filename.ext", nil),
+			str:         "AddBufferFunc( 'filename.ext', nil )",
 			expectErr:   unknown,
 		}, {
-			description: "AddBufferFn( filename.ext, bytes )",
-			opt:         AddBufferFn("filename.ext", retBuf),
-			str:         "AddBufferFn( 'filename.ext', custom )",
+			description: "AddBufferFunc( filename.ext, bytes )",
+			opt:         AddBufferFunc("filename.ext", retBuf),
+			str:         "AddBufferFunc( 'filename.ext', custom )",
 			check: func(cfg *options) bool {
 				if len(cfg.values) == 1 {
 					if cfg.values[0].name == "filename.ext" {
-						if cfg.values[0].buf.fn != nil {
+						if cfg.values[0].buf.getter != nil {
 							return true
 						}
 					}
@@ -540,13 +540,13 @@ func TestOptions(t *testing.T) {
 				return false
 			},
 		}, {
-			description: "AddValueFn( record1, '', func )",
-			opt:         AddValueFn("record1", Root, func(_ string, un UnmarshalFunc) (any, error) { return nil, nil }),
-			str:         "AddValueFn( 'record1', '', custom, none )",
+			description: "AddValueFunc( record1, '', func )",
+			opt:         AddValueFunc("record1", Root, func(_ string, un Unmarshaller) (any, error) { return nil, nil }),
+			str:         "AddValueFunc( 'record1', '', custom, none )",
 			check: func(cfg *options) bool {
 				if len(cfg.values) == 1 {
 					if cfg.values[0].name == "record1" {
-						if cfg.values[0].val.fn != nil {
+						if cfg.values[0].val.getter != nil {
 							return true
 						}
 					}
@@ -554,13 +554,13 @@ func TestOptions(t *testing.T) {
 				return false
 			},
 		}, {
-			description: "AddValueFn( record1, 'key', nil )",
-			opt:         AddValueFn("record1", "key", nil),
-			str:         "AddValueFn( 'record1', 'key', '', none )",
+			description: "AddValueFunc( record1, 'key', nil )",
+			opt:         AddValueFunc("record1", "key", nil),
+			str:         "AddValueFunc( 'record1', 'key', '', none )",
 			check: func(cfg *options) bool {
 				if len(cfg.values) == 1 {
 					if cfg.values[0].name == "record1" {
-						if cfg.values[0].val.fn == nil {
+						if cfg.values[0].val.getter == nil {
 							return true
 						}
 					}
@@ -574,7 +574,7 @@ func TestOptions(t *testing.T) {
 			check: func(cfg *options) bool {
 				if len(cfg.values) == 1 {
 					if cfg.values[0].name == "record1" {
-						if cfg.values[0].val.fn != nil {
+						if cfg.values[0].val.getter != nil {
 							return true
 						}
 					}
@@ -588,7 +588,7 @@ func TestOptions(t *testing.T) {
 			check: func(cfg *options) bool {
 				if len(cfg.defaults) == 1 {
 					if cfg.defaults[0].name == "record1" {
-						if cfg.defaults[0].val.fn != nil {
+						if cfg.defaults[0].val.getter != nil {
 							return true
 						}
 					}
@@ -602,7 +602,7 @@ func TestOptions(t *testing.T) {
 			check: func(cfg *options) bool {
 				if len(cfg.values) == 1 {
 					if cfg.values[0].name == "record1" {
-						if cfg.values[0].val.fn != nil {
+						if cfg.values[0].val.getter != nil {
 							return true
 						}
 					}
@@ -621,7 +621,7 @@ func TestOptions(t *testing.T) {
 			check: func(cfg *options) bool {
 				if len(cfg.defaults) == 1 {
 					if cfg.defaults[0].name == "filename.ext" {
-						if cfg.defaults[0].buf.fn != nil {
+						if cfg.defaults[0].buf.getter != nil {
 							return true
 						}
 					}
@@ -635,7 +635,7 @@ func TestOptions(t *testing.T) {
 			check: func(cfg *options) bool {
 				if len(cfg.values) == 1 {
 					if cfg.values[0].name == "filename.ext" {
-						if cfg.values[0].buf.fn != nil {
+						if cfg.values[0].buf.getter != nil {
 							return true
 						}
 					}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1581,7 +1581,7 @@ func TestOrigin_OriginString(t *testing.T) {
 }
 
 func TestIsSerializable(t *testing.T) {
-	fn := func() {}
+	testFunc := func() {}
 	ch := make(chan string)
 
 	tests := []struct {
@@ -1602,13 +1602,13 @@ func TestIsSerializable(t *testing.T) {
 			description: "functions can't be serialized",
 			expected:    false,
 			thing: Object{
-				Value: fn,
+				Value: testFunc,
 			},
 		}, {
 			description: "pointers to functions can't be serialized",
 			expected:    false,
 			thing: Object{
-				Value: &fn,
+				Value: &testFunc,
 			},
 		}, {
 			description: "channels can't be serialized",
@@ -1771,7 +1771,7 @@ func TestAdaptToRaw(t *testing.T) {
 	tests := []struct {
 		description string
 		thing       Object
-		fn          func(from, to reflect.Value) (any, error)
+		adapter     func(from, to reflect.Value) (any, error)
 		expected    Object
 		expectedErr error
 	}{
@@ -1782,7 +1782,7 @@ func TestAdaptToRaw(t *testing.T) {
 		}, {
 			description: "duration adapter",
 			thing:       common,
-			fn: func(from, to reflect.Value) (any, error) {
+			adapter: func(from, to reflect.Value) (any, error) {
 				if from.Type() == reflect.TypeOf(time.Second) &&
 					to.Type() == reflect.TypeOf("string") {
 					return from.Interface().(time.Duration).String(), nil
@@ -1824,7 +1824,7 @@ func TestAdaptToRaw(t *testing.T) {
 		}, {
 			description: "time adapter",
 			thing:       common,
-			fn: func(from, to reflect.Value) (any, error) {
+			adapter: func(from, to reflect.Value) (any, error) {
 				if from.Type() == reflect.TypeOf(time.Time{}) &&
 					to.Type() == reflect.TypeOf("string") {
 					return from.Interface().(time.Time).Format("2006"), nil
@@ -1866,7 +1866,7 @@ func TestAdaptToRaw(t *testing.T) {
 		}, {
 			description: "return an error for the 'other' string field",
 			thing:       common,
-			fn: func(from, to reflect.Value) (any, error) {
+			adapter: func(from, to reflect.Value) (any, error) {
 				if from.Type() == reflect.TypeOf("string") {
 					return nil, unknownErr
 				}
@@ -1879,7 +1879,7 @@ func TestAdaptToRaw(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			assert := assert.New(t)
 
-			got, err := tc.thing.AdaptToRaw(tc.fn)
+			got, err := tc.thing.AdaptToRaw(tc.adapter)
 
 			assert.Empty(cmp.Diff(tc.expected, got, cmpopts.IgnoreUnexported(Object{})))
 			if tc.expectedErr == nil {

--- a/record.go
+++ b/record.go
@@ -18,9 +18,9 @@ type record struct {
 }
 
 // fetch normalizes the calls to the val or encoded types of records.
-func (rec *record) fetch(delimiter string, umf UnmarshalFunc, decoders *codecRegistry[decoder.Decoder], defaultOpts []ValueOption) error {
+func (rec *record) fetch(delimiter string, u Unmarshaller, decoders *codecRegistry[decoder.Decoder], defaultOpts []ValueOption) error {
 	if rec.val != nil {
-		tree, err := rec.val.toTree(delimiter, umf, defaultOpts...)
+		tree, err := rec.val.toTree(delimiter, u, defaultOpts...)
 		if err != nil {
 			return err
 		}
@@ -28,7 +28,7 @@ func (rec *record) fetch(delimiter string, umf UnmarshalFunc, decoders *codecReg
 	}
 
 	if rec.buf != nil {
-		tree, err := rec.buf.toTree(delimiter, umf, decoders)
+		tree, err := rec.buf.toTree(delimiter, u, decoders)
 		if err != nil {
 			return err
 		}

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -230,7 +230,7 @@ func TestUnmarshal(t *testing.T) {
 			want:        simple{},
 			expectedErr: unknownErr,
 		}, {
-			description: "Verify the WithValidator(fn) behavior works.",
+			description: "Verify the WithValidator(func) behavior works.",
 			input:       `{"Foo":"bar"}`,
 			opts:        []UnmarshalOption{WithValidator(func(any) error { return nil })},
 			want:        simple{},
@@ -294,10 +294,10 @@ func TestUnmarshal(t *testing.T) {
 				Delta: "tree val",
 			},
 		}, {
-			description: "Verify the KeymapFn() works",
+			description: "Verify the KeymapFunc() works",
 			input:       `{"foo":"bar"}`,
 			opts: []UnmarshalOption{
-				KeymapFn(func(s string) string {
+				KeymapFunc(func(s string) string {
 					return strings.ToLower(s)
 				}),
 			},
@@ -306,7 +306,7 @@ func TestUnmarshal(t *testing.T) {
 				Foo: "bar",
 			},
 		}, {
-			description: "Verify the WithValidator(fn) failure mode works.",
+			description: "Verify the WithValidator(func) failure mode works.",
 			input:       `{"Foo":"bar"}`,
 			opts: []UnmarshalOption{
 				WithValidator(func(any) error { return unknownErr }),
@@ -416,7 +416,7 @@ func TestUnmarshal(t *testing.T) {
 	}
 }
 
-func TestUnmarshalFn(t *testing.T) {
+func TestUnmarshalFunc(t *testing.T) {
 	type sub struct {
 		Foo string
 	}
@@ -466,10 +466,10 @@ func TestUnmarshalFn(t *testing.T) {
 				}
 			}
 
-			fn := UnmarshalFn[sub](tc.key, tc.opts...)
-			require.NotNil(fn)
+			resultingFunc := UnmarshalFunc[sub](tc.key, tc.opts...)
+			require.NotNil(resultingFunc)
 
-			got, err := fn(g)
+			got, err := resultingFunc(g)
 
 			if tc.expectedErr == false {
 				assert.NoError(err)

--- a/unmarshalvalue.go
+++ b/unmarshalvalue.go
@@ -83,16 +83,16 @@ func Keymap(m map[string]string) UnmarshalValueOption {
 	}
 }
 
-// KeymapFn takes a Mapper function and adds it to the existing chain of
+// KeymapFunc takes a Mapper function and adds it to the existing chain of
 // mappers, in the front of the list.
 //
 // This allows for multiple mappers to be specified instead of requiring a
 // single mapper with full knowledge of how to map everything. This makes it
 // easy to add logic to remap full keys without needing to re-implement the
 // underlying converters.
-func KeymapFn(mapper Mapper) UnmarshalValueOption {
+func KeymapFunc(mapper Mapper) UnmarshalValueOption {
 	return &keymapOption{
-		text: print.P("KeymapFn", print.Fn(mapper), print.SubOpt()),
+		text: print.P("KeymapFunc", print.Func(mapper), print.SubOpt()),
 		m:    mapper,
 	}
 }


### PR DESCRIPTION
BREAKING CHANGE

- Changes the use of `Fn` to be `Func` to be inline with go's naming convention.
  - Functions Changing:
    - AddBufferFn         --> AddBufferFunc
    - AddValueFn          --> AddValueFunc
    - KeymapFn            --> KeymapFunc
    - SortRecordsCustomFn --> SortRecordsCustomFunc
    - UnmarshalFn         --> UnmarshalFunc
  - Types Changing:
    - UnmarshalFunc --> Unmarshaller
- Function variables are also updated to attempt to make them better.