### PR TITLE
Fix the spelling of un/marshaler to match go's spelling.

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -26,7 +26,7 @@ func AddBuffer(recordName string, in []byte, opts ...BufferOption) Option {
 	return &buffer{
 		text:       print.P("AddBuffer", print.String(recordName), print.Bytes(in), print.LiteralStringers(opts)),
 		recordName: recordName,
-		getter: func(_ string, _ Unmarshaller) ([]byte, error) {
+		getter: func(_ string, _ Unmarshaler) ([]byte, error) {
 			return in, nil
 		},
 		opts: opts,
@@ -35,7 +35,7 @@ func AddBuffer(recordName string, in []byte, opts ...BufferOption) Option {
 
 // AddBufferFunc adds a function that is called during compile time of the
 // configuration.  The recordName of this record is passed into the getter
-// function that is called as well as an Unmarshaller that represents the
+// function that is called as well as an Unmarshaler that represents the
 // existing state of the merged configuration prior to adding the buffer that
 // results in the call to getter.
 //
@@ -47,7 +47,7 @@ func AddBuffer(recordName string, in []byte, opts ...BufferOption) Option {
 //   - [BufferOption]
 //   - [BufferValueOption]
 //   - [GlobalOption]
-func AddBufferFunc(recordName string, getter func(recordName string, u Unmarshaller) ([]byte, error), opts ...BufferOption) Option {
+func AddBufferFunc(recordName string, getter func(recordName string, u Unmarshaler) ([]byte, error), opts ...BufferOption) Option {
 	rv := buffer{
 		text:       print.P("AddBufferFunc", print.String(recordName), print.Func(getter), print.LiteralStringers(opts)),
 		recordName: recordName,
@@ -55,7 +55,7 @@ func AddBufferFunc(recordName string, getter func(recordName string, u Unmarshal
 	}
 
 	if getter != nil {
-		rv.getter = func(name string, u Unmarshaller) ([]byte, error) {
+		rv.getter = func(name string, u Unmarshaler) ([]byte, error) {
 			return getter(name, u)
 		}
 	}
@@ -71,7 +71,7 @@ type buffer struct {
 	recordName string
 
 	// The function to use to get the value.
-	getter func(string, Unmarshaller) ([]byte, error)
+	getter func(string, Unmarshaler) ([]byte, error)
 
 	// Options that configure how this buffer is treated and processed.
 	// These options are in addition to any default settings set with
@@ -118,7 +118,7 @@ func (b buffer) String() string {
 
 // toTree converts an buffer into a meta.Object tree.  This will happen
 // during the compilation stage.
-func (b *buffer) toTree(delimiter string, u Unmarshaller, decoders *codecRegistry[decoder.Decoder]) (meta.Object, error) {
+func (b *buffer) toTree(delimiter string, u Unmarshaler, decoders *codecRegistry[decoder.Decoder]) (meta.Object, error) {
 	data, err := b.getter(b.recordName, u)
 	if err != nil {
 		return meta.Object{}, err

--- a/goschtalt_test.go
+++ b/goschtalt_test.go
@@ -204,7 +204,7 @@ func TestCompile(t *testing.T) {
 			opts: []Option{
 				AddBuffer("3.json", []byte(`{"Madd": "cat"}`)),
 				AddBuffer("2.json", []byte(`{"Blue": "${thing}"}`)),
-				AddBufferFunc("1.json", func(_ string, _ Unmarshaller) ([]byte, error) {
+				AddBufferFunc("1.json", func(_ string, _ Unmarshaler) ([]byte, error) {
 					return []byte(`{"Hello": "Mr. Blue Sky"}`), nil
 				}),
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
@@ -221,12 +221,12 @@ func TestCompile(t *testing.T) {
 			description: "A case with an encoded buffer function that looks up something from the tree.",
 			opts: []Option{
 				AddBuffer("1.json", []byte(`{"Madd": "cat"}`)),
-				AddBufferFunc("2.json", func(_ string, un Unmarshaller) ([]byte, error) {
+				AddBufferFunc("2.json", func(_ string, un Unmarshaler) ([]byte, error) {
 					var s string
 					_ = un("Madd", &s)
 					return []byte(fmt.Sprintf(`{"Blue": "%s"}`, s)), nil
 				}),
-				AddBufferFunc("3.json", func(_ string, un Unmarshaller) ([]byte, error) {
+				AddBufferFunc("3.json", func(_ string, un Unmarshaler) ([]byte, error) {
 					var s string
 					_ = un("Blue", &s)
 					return []byte(fmt.Sprintf(`{"Hello": "%s"}`, s)), nil
@@ -273,7 +273,7 @@ func TestCompile(t *testing.T) {
 			opts: []Option{
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
 				AutoCompile(),
-				AddBufferFunc("3.json", func(_ string, _ Unmarshaller) ([]byte, error) {
+				AddBufferFunc("3.json", func(_ string, _ Unmarshaler) ([]byte, error) {
 					return nil, unknownErr
 				}),
 			},
@@ -284,7 +284,7 @@ func TestCompile(t *testing.T) {
 			opts: []Option{
 				WithDecoder(&testDecoder{extensions: []string{"json"}}),
 				AutoCompile(),
-				AddBufferFunc("3.json", func(_ string, _ Unmarshaller) ([]byte, error) {
+				AddBufferFunc("3.json", func(_ string, _ Unmarshaler) ([]byte, error) {
 					return []byte(`invalid`), nil
 				}),
 			},
@@ -529,7 +529,7 @@ func TestCompile(t *testing.T) {
 			opts: []Option{
 				AutoCompile(),
 				AddValueFunc("record", Root,
-					func(string, Unmarshaller) (any, error) {
+					func(string, Unmarshaler) (any, error) {
 						return nil, testErr
 					},
 				),

--- a/options_test.go
+++ b/options_test.go
@@ -31,7 +31,7 @@ func TestOptions(t *testing.T) {
 	list := []string{"zeta", "alpha", "19beta", "19alpha", "4tango",
 		"1alpha", "7alpha", "bravo", "7alpha10", "7alpha2", "7alpha0"}
 
-	retBuf := func(name string, un Unmarshaller) ([]byte, error) {
+	retBuf := func(name string, un Unmarshaler) ([]byte, error) {
 		return []byte(name), nil
 	}
 
@@ -541,7 +541,7 @@ func TestOptions(t *testing.T) {
 			},
 		}, {
 			description: "AddValueFunc( record1, '', func )",
-			opt:         AddValueFunc("record1", Root, func(_ string, un Unmarshaller) (any, error) { return nil, nil }),
+			opt:         AddValueFunc("record1", Root, func(_ string, un Unmarshaler) (any, error) { return nil, nil }),
 			str:         "AddValueFunc( 'record1', '', custom, none )",
 			check: func(cfg *options) bool {
 				if len(cfg.values) == 1 {

--- a/record.go
+++ b/record.go
@@ -18,7 +18,7 @@ type record struct {
 }
 
 // fetch normalizes the calls to the val or encoded types of records.
-func (rec *record) fetch(delimiter string, u Unmarshaller, decoders *codecRegistry[decoder.Decoder], defaultOpts []ValueOption) error {
+func (rec *record) fetch(delimiter string, u Unmarshaler, decoders *codecRegistry[decoder.Decoder], defaultOpts []ValueOption) error {
 	if rec.val != nil {
 		tree, err := rec.val.toTree(delimiter, u, defaultOpts...)
 		if err != nil {

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -15,12 +15,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-// Unmarshaller provides a special use [Unmarshal]() function during [AddBufferFunc]()
+// Unmarshaler provides a special use [Unmarshal]() function during [AddBufferFunc]()
 // and [AddValueFunc]() option provided callbacks.  This pattern allows the specified
 // function access to the configuration values up to this point.  Expansion of
 // any [Expand]() or [ExpandEnv]() options is also applied to the configuration tree
 // provided.
-type Unmarshaller func(key string, result any, opts ...UnmarshalOption) error
+type Unmarshaler func(key string, result any, opts ...UnmarshalOption) error
 
 // Unmarshal provides a generics based strict typed approach to fetching parts
 // of the configuration tree.
@@ -44,7 +44,7 @@ func Unmarshal[T any](c *Config, key string, opts ...UnmarshalOption) (T, error)
 }
 
 // UnmarshalFunc returns a function that takes a goschtalt Config structure and
-// returns a function that allows for unmarshalling of a portion of the tree
+// returns a function that allows for unmarshaling of a portion of the tree
 // specified by the key into a zero value type.
 //
 // This function is specifically helpful with DI frameworks like Uber's fx

--- a/value.go
+++ b/value.go
@@ -29,7 +29,7 @@ func AddValue(recordName, key string, val any, opts ...ValueOption) Option {
 		text:       "AddValue",
 		recordName: recordName,
 		key:        key,
-		getter: func(_ string, _ Unmarshaller) (any, error) {
+		getter: func(_ string, _ Unmarshaler) (any, error) {
 			return val, nil
 		},
 		opts: opts,
@@ -49,7 +49,7 @@ func AddValue(recordName, key string, val any, opts ...ValueOption) Option {
 //   - [GlobalOption]
 //   - [ValueOption]
 //   - [UnmarshalValueOption]
-func AddValueFunc(recordName, key string, f func(recordName string, u Unmarshaller) (any, error), opts ...ValueOption) Option {
+func AddValueFunc(recordName, key string, f func(recordName string, u Unmarshaler) (any, error), opts ...ValueOption) Option {
 	return &value{
 		text:       "AddValueFunc",
 		recordName: recordName,
@@ -70,7 +70,7 @@ type value struct {
 	key string
 
 	// The function to use to get the value.
-	getter func(recordName string, u Unmarshaller) (any, error)
+	getter func(recordName string, u Unmarshaler) (any, error)
 
 	// Options that configure how to process the Value provided.
 	// These options are in addition to any default settings set with
@@ -80,7 +80,7 @@ type value struct {
 
 // toTree does the work of converting from a structure of some sort to the
 // normalized object tree goschtalt uses.
-func (v value) toTree(delimiter string, u Unmarshaller, defaultOpts ...ValueOption) (meta.Object, error) {
+func (v value) toTree(delimiter string, u Unmarshaler, defaultOpts ...ValueOption) (meta.Object, error) {
 	cfg := valueOptions{
 		tagName: defaultTag,
 	}


### PR DESCRIPTION
BREAKING CHANGE

- Type name changes:
   - Unmarshaller --> Unmarshaler