### PR TITLE
feat!:Replace funcs with interfaces

### DIFF
--- a/goschtalt.go
+++ b/goschtalt.go
@@ -199,7 +199,14 @@ func (c *Config) compile() error { //nolint:funlen
 		incremental := merged
 		for _, exp := range c.opts.expansions {
 			var err error
-			incremental, err = incremental.ToExpanded(exp.maximum, exp.origin, exp.start, exp.end, exp.mapper)
+			incremental, err = incremental.ToExpanded(
+				exp.maximum,
+				exp.origin,
+				exp.start,
+				exp.end,
+				func(s string) string { return exp.expander.Expand(s) },
+			)
+
 			if err != nil {
 				fmt.Fprintf(&c.explainCompile, "Error: %s\n", err)
 				return err
@@ -230,7 +237,13 @@ func (c *Config) compile() error { //nolint:funlen
 		fmt.Fprintf(&c.explainCompile, "  %d. %s\n", i+1, exp.String())
 
 		var err error
-		merged, err = merged.ToExpanded(exp.maximum, exp.origin, exp.start, exp.end, exp.mapper)
+		merged, err = merged.ToExpanded(
+			exp.maximum,
+			exp.origin,
+			exp.start,
+			exp.end,
+			func(s string) string { return exp.expander.Expand(s) },
+		)
 		if err != nil {
 			fmt.Fprintf(&c.explainCompile, "Error: %s\n", err)
 			return err
@@ -258,7 +271,7 @@ done:
 func (c *Config) getSorter() func([]record) {
 	return func(a []record) {
 		sort.SliceStable(a, func(i, j int) bool {
-			return c.opts.sorter(a[i].name, a[j].name)
+			return c.opts.sorter.Less(a[i].name, a[j].name)
 		})
 	}
 }

--- a/pkg/adapter/duration.go
+++ b/pkg/adapter/duration.go
@@ -13,10 +13,18 @@ import (
 // DurationUnmarshal converts a string to a time.Duration or *time.Duration if
 // possible, or returns an error indicating the failure.
 func DurationUnmarshal() goschtalt.UnmarshalOption {
-	return goschtalt.AdaptFromCfg(stringToDuration, "DurationUnmarshal")
+	return goschtalt.AdaptFromCfg(marshalDuration{}, "DurationUnmarshal")
 }
 
-func stringToDuration(from, to reflect.Value) (any, error) {
+// MarshalDuration converts a time.Duration into its configuration form.  The
+// configuration form is a string.
+func MarshalDuration() goschtalt.ValueOption {
+	return goschtalt.AdaptToCfg(marshalDuration{}, "MarshalDuration")
+}
+
+type marshalDuration struct{}
+
+func (marshalDuration) From(from, to reflect.Value) (any, error) {
 	if from.Kind() != reflect.String {
 		return nil, goschtalt.ErrNotApplicable
 	}
@@ -41,13 +49,7 @@ func stringToDuration(from, to reflect.Value) (any, error) {
 	return d, nil
 }
 
-// MarshalDuration converts a time.Duration into its configuration form.  The
-// configuration form is a string.
-func MarshalDuration() goschtalt.ValueOption {
-	return goschtalt.AdaptToCfg(durationToCfg, "MarshalDuration")
-}
-
-func durationToCfg(from reflect.Value) (any, error) {
+func (marshalDuration) To(from reflect.Value) (any, error) {
 	if from.Type() == reflect.TypeOf(time.Duration(1)) {
 		return from.Interface().(time.Duration).String(), nil
 	}

--- a/pkg/adapter/time.go
+++ b/pkg/adapter/time.go
@@ -24,33 +24,37 @@ func AllButTime(t any) bool {
 // error indicating the failure.  The specified layout is used as the string
 // form.
 func TimeUnmarshal(layout string) goschtalt.UnmarshalOption {
-	return goschtalt.AdaptFromCfg(stringToTime(layout), "TimeUnmarshal")
-}
-
-func stringToTime(layout string) func(reflect.Value, reflect.Value) (any, error) {
-	return func(from, to reflect.Value) (any, error) {
-		if from.Kind() == reflect.String && to.Type() == reflect.TypeOf(time.Time{}) {
-			a, e := time.Parse(layout, from.Interface().(string))
-			return a, e
-		}
-
-		return nil, goschtalt.ErrNotApplicable
-	}
+	return goschtalt.AdaptFromCfg(marshalTime{layout: layout}, "TimeUnmarshal")
 }
 
 // MarshalTime converts a time.Time into its configuration form. The
 // configuration form is a string matching the specified layout.
 func MarshalTime(layout string) goschtalt.ValueOption {
-	return goschtalt.AdaptToCfg(timeToCfg(layout), "MarshalTime")
+	return goschtalt.AdaptToCfg(marshalTime{layout}, "MarshalTime")
 }
 
-func timeToCfg(layout string) func(reflect.Value) (any, error) {
-	return func(from reflect.Value) (any, error) {
-		if from.Type() == reflect.TypeOf(time.Time{}) {
-			a := from.Interface().(time.Time).Format(layout)
-			return a, nil
-		}
+type marshalTime struct {
+	layout string
+}
 
-		return nil, goschtalt.ErrNotApplicable
+func (t marshalTime) From(from, to reflect.Value) (any, error) {
+	if from.Kind() == reflect.String && to.Type() == reflect.TypeOf(time.Time{}) {
+		a, e := time.Parse(t.layout, from.Interface().(string))
+		return a, e
 	}
+
+	return nil, goschtalt.ErrNotApplicable
+}
+
+func (t marshalTime) To(from reflect.Value) (any, error) {
+	if from.Type() == reflect.TypeOf(time.Time{}) {
+		a := from.Interface().(time.Time).Format(t.layout)
+		return a, nil
+	}
+
+	return nil, goschtalt.ErrNotApplicable
+}
+
+func (t marshalTime) String() string {
+	return t.layout
 }

--- a/unmarshal_test.go
+++ b/unmarshal_test.go
@@ -231,8 +231,10 @@ func TestUnmarshal(t *testing.T) {
 		}, {
 			description: "Verify the WithValidator(func) behavior works.",
 			input:       `{"Foo":"bar"}`,
-			opts:        []UnmarshalOption{WithValidator(func(any) error { return nil })},
-			want:        simple{},
+			opts: []UnmarshalOption{
+				WithValidator(mockValidator{f: func(any) error { return nil }}),
+			},
+			want: simple{},
 			expected: simple{
 				Foo: "bar",
 			},
@@ -240,7 +242,7 @@ func TestUnmarshal(t *testing.T) {
 			description: "Verify the WithValidator(nil) behavior works.",
 			input:       `{"Foo":"bar"}`,
 			opts: []UnmarshalOption{
-				WithValidator(func(any) error { return unknownErr }),
+				WithValidator(mockValidator{f: func(any) error { return unknownErr }}),
 				WithValidator(nil),
 			},
 			want: simple{},
@@ -293,11 +295,13 @@ func TestUnmarshal(t *testing.T) {
 				Delta: "tree val",
 			},
 		}, {
-			description: "Verify the KeymapFunc() works",
+			description: "Verify the KeymapMapper() works",
 			input:       `{"foo":"bar"}`,
 			opts: []UnmarshalOption{
-				KeymapFunc(func(s string) string {
-					return strings.ToLower(s)
+				KeymapMapper(mockMapper{
+					f: func(s string) string {
+						return strings.ToLower(s)
+					},
 				}),
 			},
 			want: simple{},
@@ -308,7 +312,7 @@ func TestUnmarshal(t *testing.T) {
 			description: "Verify the WithValidator(func) failure mode works.",
 			input:       `{"Foo":"bar"}`,
 			opts: []UnmarshalOption{
-				WithValidator(func(any) error { return unknownErr }),
+				WithValidator(mockValidator{f: func(any) error { return unknownErr }}),
 			},
 			want:        simple{},
 			expectedErr: unknownErr,
@@ -351,11 +355,13 @@ func TestUnmarshal(t *testing.T) {
 			key:         "Foo",
 			want:        time.Time{},
 			opts: []UnmarshalOption{
-				AdaptFromCfg(func(f, t reflect.Value) (any, error) {
-					if f.Kind() != reflect.String {
-						return f.Interface(), nil
-					}
-					return time.Parse("2006-01-02", f.Interface().(string))
+				AdaptFromCfg(mockAdapterFromCfg{
+					f: func(f, t reflect.Value) (any, error) {
+						if f.Kind() != reflect.String {
+							return f.Interface(), nil
+						}
+						return time.Parse("2006-01-02", f.Interface().(string))
+					},
 				}),
 			},
 			expected: time.Date(2022, time.May, 1, 0, 0, 0, 0, time.UTC),


### PR DESCRIPTION
BREAKING CHANGE

Replace funcs with interfaces for basically everything.  This provides a few values:

- It's more clear what customization is present in goschtalt.
- It's a bit easier to use an object for adapters and the like.
- The documentation looks like it will be easier to write and understand.