### PR TITLE
Replace explanation logic.

### DIFF
--- a/explanation.go
+++ b/explanation.go
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: 2023 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+package goschtalt
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/goschtalt/goschtalt/pkg/debug"
+)
+
+// Explanation is the structure that represents what happened last time the
+// Config object was altered, compiled or used.
+//
+// Calling New() or With() will clear out all the values present.
+type Explanation struct {
+	// -- Configuration based information --------------------------------------
+
+	// Options is the ordered list of Options in effect.
+	Options []string
+
+	// FileExtensions is the list of file extensions supported in the
+	// configuration provided.
+	FileExtensions []string
+
+	// -- Compilation based information ----------------------------------------
+
+	// CompileStartedAt is the start time when the most recent compile was
+	// performed.
+	CompileStartedAt time.Time
+
+	// CompileFinishedAt is the completion time when the most recent compile was
+	// performed.
+	CompileFinishedAt time.Time
+
+	// Records is the ordered list of records processed.
+	Records []ExplanationRecord
+
+	// VariableExpansions is the ordered list of variable expansion instructions
+	// applied.
+	VariableExpansions []string
+
+	// CompileErrors is the ordered list of compilation errors encountered during
+	// the last compilation.
+	CompileErrors []error
+
+	// -- Marshaling/Unmarshaling based information ----------------------------
+
+	// Keyremapping collects the key remapping that happens when values are
+	// added or used.  This helps address problems when a name may not be
+	// converted the way you would expect or like.
+	//
+	// Not available if DisableDefaultPackageOptions() is specified.
+	Keyremapping debug.Collect
+}
+
+// ExplanationRecord is the structure that represents a specific record that was
+// processed.
+type ExplanationRecord struct {
+	Name     string        // The name of the record.
+	Default  bool          // If the record was marked as a 'default' record.
+	Duration time.Duration // The time needed to process the record.
+}
+
+func (er ExplanationRecord) String() string {
+	empty := ExplanationRecord{}
+	if er == empty {
+		return ""
+	}
+
+	user := "user"
+	if er.Default {
+		user = "default"
+	}
+	return fmt.Sprintf("'%s' <%s> (%s)", er.Name, user, er.Duration)
+}
+
+func (e *Explanation) reset() {
+	e.Options = []string{}
+	e.FileExtensions = []string{}
+	e.compileReset()
+	e.Keyremapping.Reset()
+}
+
+func (e *Explanation) optionInEffect(s string) {
+	e.Options = append(e.Options, s)
+}
+
+func (e *Explanation) extsSupported(s []string) {
+	e.FileExtensions = append(e.FileExtensions, s...)
+}
+
+func (e *Explanation) compileReset() {
+	e.CompileStartedAt = time.Time{}
+	e.Records = []ExplanationRecord{}
+	e.VariableExpansions = []string{}
+	e.CompileErrors = []error{}
+}
+
+func (e *Explanation) compileStartedAt(t time.Time) {
+	e.CompileStartedAt = t
+	e.Records = []ExplanationRecord{}
+	e.VariableExpansions = []string{}
+	e.CompileErrors = []error{}
+}
+
+func (e *Explanation) compileRecord(name string, isDefault bool, now time.Time) {
+	elapsed := now.Sub(e.CompileStartedAt)
+	for _, record := range e.Records {
+		elapsed -= record.Duration
+	}
+
+	e.Records = append(e.Records,
+		ExplanationRecord{
+			Name:     name,
+			Default:  isDefault,
+			Duration: elapsed,
+		})
+}
+
+func (e *Explanation) compileExpansions(details string) {
+	e.VariableExpansions = append(e.VariableExpansions, details)
+}
+
+func (e *Explanation) recordError(err error) {
+	if err != nil {
+		e.CompileErrors = append(e.CompileErrors, err)
+	}
+}
+
+func (e Explanation) String() string {
+	var b strings.Builder
+
+	fmt.Fprintln(&b, "# Options")
+	fmt.Fprintln(&b, "")
+	fmt.Fprintln(&b, "## Options in effect")
+	fmt.Fprintln(&b, "")
+	for i, opt := range e.Options {
+		fmt.Fprintf(&b, "  %d. %s\n", i+1, opt)
+	}
+	fmt.Fprintln(&b, "")
+	fmt.Fprintln(&b, "## File extensions supported:")
+	fmt.Fprintln(&b, "")
+	if len(e.FileExtensions) == 0 {
+		fmt.Fprintln(&b, "  <none>")
+	} else {
+		for _, ext := range e.FileExtensions {
+			fmt.Fprintf(&b, "  - %s\n", ext)
+		}
+	}
+
+	fmt.Fprintln(&b, "")
+	fmt.Fprintln(&b, "# Compilation")
+	fmt.Fprintln(&b, "")
+	fmt.Fprintf(&b, "  - Started at:  %s\n", e.CompileStartedAt.Format(time.RFC3339))
+	fmt.Fprintf(&b, "  - Duration: %s\n", e.CompileFinishedAt.Sub(e.CompileStartedAt))
+	if len(e.CompileErrors) == 0 {
+		fmt.Fprintln(&b, "  - Errors: none")
+	} else {
+		fmt.Fprintln(&b, "  - Errors:")
+		for _, err := range e.CompileErrors {
+			fmt.Fprintf(&b, "    - %s\n", err)
+		}
+	}
+	fmt.Fprintln(&b, "")
+	fmt.Fprintln(&b, "## Records processed in order.")
+	fmt.Fprintln(&b, "")
+	if len(e.Records) == 0 {
+		fmt.Fprintln(&b, "  <none>")
+	} else {
+		max := 0
+		for _, record := range e.Records {
+			if len(record.Name) > max {
+				max = len(record.Name)
+			}
+		}
+
+		for i, record := range e.Records {
+			fmt.Fprintf(&b, "  %d. %s\n", i+1, record.String())
+		}
+	}
+	fmt.Fprintln(&b, "")
+	fmt.Fprintln(&b, "## Variable expansions processed in order.")
+	fmt.Fprintln(&b, "")
+	if len(e.VariableExpansions) == 0 {
+		fmt.Fprintln(&b, "  <none>")
+	} else {
+		for i, expansion := range e.VariableExpansions {
+			fmt.Fprintf(&b, "  %d. %s\n", i+1, expansion)
+		}
+	}
+
+	fmt.Fprintln(&b, "")
+	fmt.Fprintln(&b, "# Structure name remapping")
+	fmt.Fprintln(&b, "")
+	rm := e.Keyremapping.String()
+	if rm != "" {
+		rm = "  - " + rm
+		rm = strings.TrimSuffix(rm, "\n")
+		rm = strings.ReplaceAll(rm, "\n", "\n  - ")
+	}
+	fmt.Fprintln(&b, rm)
+	fmt.Fprintln(&b, "")
+
+	return b.String()
+}

--- a/explanation_test.go
+++ b/explanation_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2023 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+package goschtalt
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExplainerRecord(t *testing.T) {
+	tests := []struct {
+		in   ExplanationRecord
+		want string
+	}{
+		{
+			in:   ExplanationRecord{},
+			want: "",
+		}, {
+			in: ExplanationRecord{
+				Name:     "non-default-record",
+				Duration: time.Second,
+			},
+			want: "'non-default-record' <user> (1s)",
+		}, {
+			in: ExplanationRecord{
+				Name:     "default-record",
+				Duration: time.Second,
+				Default:  true,
+			},
+			want: "'default-record' <default> (1s)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.want, func(t *testing.T) {
+			assert := assert.New(t)
+
+			assert.Equal(tc.want, tc.in.String())
+		})
+	}
+}
+
+func TestCompileRecord(t *testing.T) {
+	tests := []struct {
+		description string
+		in          Explanation
+		add         string
+		Default     bool
+		want        Explanation
+	}{
+		{
+			description: "basic one step test",
+			in:          Explanation{},
+			add:         "one",
+			want: Explanation{
+				Records: []ExplanationRecord{
+					{
+						Name:     "one",
+						Duration: 10 * time.Second,
+					},
+				},
+			},
+		},
+		{
+			description: "basic two step test",
+			in: Explanation{
+				Records: []ExplanationRecord{
+					{
+						Name:     "one",
+						Duration: 5 * time.Second,
+					},
+				},
+			},
+			add: "two",
+			want: Explanation{
+				Records: []ExplanationRecord{
+					{
+						Name:     "one",
+						Duration: 5 * time.Second,
+					},
+					{
+						Name:     "two",
+						Duration: 5 * time.Second,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+
+			start := time.Now()
+			end := start.Add(10 * time.Second)
+
+			tc.in.CompileStartedAt = start
+			tc.want.CompileStartedAt = start
+			tc.in.compileRecord(tc.add, tc.Default, end)
+
+			assert.Equal(tc.want, tc.in)
+		})
+	}
+}

--- a/goschtalt_most_test.go
+++ b/goschtalt_most_test.go
@@ -317,7 +317,7 @@ func TestCompileNotWin(t *testing.T) {
 
 			var tell string
 			if cfg != nil {
-				tell = cfg.Explain()
+				tell = cfg.Explain().String()
 			}
 
 			if tc.expectedErr == nil {
@@ -333,9 +333,7 @@ func TestCompileNotWin(t *testing.T) {
 				}
 
 				// check the file order
-				got, err := cfg.ShowOrder()
-				require.NoError(err)
-				assert.Equal(tc.files, got)
+				assert.Equal(tc.files, cfg.records)
 
 				assert.NotEmpty(tell)
 
@@ -354,9 +352,7 @@ func TestCompileNotWin(t *testing.T) {
 
 			if !tc.compileOption {
 				// check the file order is correct
-				got, err := cfg.ShowOrder()
-				assert.ErrorIs(err, ErrNotCompiled)
-				assert.Empty(got)
+				assert.Empty(cfg.explain.Records)
 				assert.NotEmpty(tell)
 			}
 		})

--- a/goschtalt_test.go
+++ b/goschtalt_test.go
@@ -800,7 +800,7 @@ func TestCompile(t *testing.T) {
 
 			var tell string
 			if cfg != nil {
-				tell = cfg.Explain()
+				tell = cfg.Explain().String()
 			}
 
 			if tc.expectedErr == nil {
@@ -816,9 +816,11 @@ func TestCompile(t *testing.T) {
 				}
 
 				// check the file order
-				got, err := cfg.ShowOrder()
-				require.NoError(err)
-				assert.Equal(tc.files, got)
+				if tc.files == nil {
+					assert.Empty(cfg.records)
+				} else {
+					assert.Equal(tc.files, cfg.records)
+				}
 
 				assert.NotEmpty(tell)
 
@@ -837,9 +839,7 @@ func TestCompile(t *testing.T) {
 
 			if !tc.compileOption {
 				// check the file order is correct
-				got, err := cfg.ShowOrder()
-				assert.ErrorIs(err, ErrNotCompiled)
-				assert.Empty(got)
+				assert.Empty(cfg.records)
 				assert.NotEmpty(tell)
 			}
 		})
@@ -880,37 +880,6 @@ func TestOrderList(t *testing.T) {
 			require.NoError(err)
 
 			got := cfg.OrderList(tc.in)
-
-			assert.Equal(tc.expect, got)
-		})
-	}
-}
-
-func TestExtensions(t *testing.T) {
-	tests := []struct {
-		description string
-		opts        []Option
-		expect      []string
-	}{
-		{
-			description: "An empty list",
-		}, {
-			description: "A simple list",
-			opts:        []Option{WithDecoder(&testDecoder{extensions: []string{"json"}})},
-			expect:      []string{"json"},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.description, func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-
-			cfg, err := New(tc.opts...)
-			require.NotNil(cfg)
-			require.NoError(err)
-
-			got := cfg.Extensions()
 
 			assert.Equal(tc.expect, got)
 		})


### PR DESCRIPTION
BREAKING CHANGE

This change removes ShowOrder() and Extensions() and Explain() with a new version of Explain() that returns an Explanation object.  This makes processing a bit simpler in the core code and provides some more useful objects if someone wants a different form of output.