### PR TITLE
Add HintEncoder() and HintDecoder() and general hints.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -15,4 +15,5 @@ var (
 	ErrInvalidInput  = errors.New("input is invalid")
 	ErrFileMissing   = errors.New("required file is missing")
 	ErrUnsupported   = errors.New("feature is unsupported")
+	ErrHint          = errors.New("a hint found an issue")
 )

--- a/goschtalt.go
+++ b/goschtalt.go
@@ -113,6 +113,12 @@ func (c *Config) With(opts ...Option) error {
 		}
 	}
 
+	for _, hint := range cfg.hints {
+		if err := hint(&cfg); err != nil {
+			return err
+		}
+	}
+
 	// The options are valid, record them.
 	c.opts = cfg
 	c.rawOpts = raw

--- a/goschtalt_test.go
+++ b/goschtalt_test.go
@@ -780,6 +780,46 @@ func TestCompile(t *testing.T) {
 				Hello: "World",
 			},
 			files: []string{"1.json"},
+		}, {
+			description: "Ensure the HintDecoder() can find one.",
+			opts: []Option{
+				HintDecoder("json", "http://github.com/goschtalt/json-decoder", "json"),
+				WithDecoder(&testDecoder{extensions: []string{"json"}}),
+			},
+		}, {
+			description: "Ensure the HintDecoder() can find when they are missing.",
+			opts: []Option{
+				HintDecoder("dogs", "http://github.com/goschtalt/dogs-decoder", "dogs"),
+				WithDecoder(&testDecoder{extensions: []string{"json"}}),
+			},
+			compileOption: true,
+			expectedErr:   ErrHint,
+		}, {
+			description: "Ensure the HintDecoder() can handle a partial success.",
+			opts: []Option{
+				HintDecoder("json_dogs", "http://github.com/goschtalt/dogs-decoder", "dogs", "json"),
+				WithDecoder(&testDecoder{extensions: []string{"json"}}),
+			},
+		}, {
+			description: "Ensure the HintEncoder() can find one.",
+			opts: []Option{
+				HintEncoder("json", "http://github.com/goschtalt/json-decoder", "json"),
+				WithEncoder(&testEncoder{extensions: []string{"json"}}),
+			},
+		}, {
+			description: "Ensure the HintEncoder() can find when they are missing.",
+			opts: []Option{
+				HintEncoder("dogs", "http://github.com/goschtalt/dogs-decoder", "dogs"),
+				WithEncoder(&testEncoder{extensions: []string{"json"}}),
+			},
+			compileOption: true,
+			expectedErr:   ErrHint,
+		}, {
+			description: "Ensure the HintEncoder() can handle a partial success.",
+			opts: []Option{
+				HintEncoder("json_dogs", "http://github.com/goschtalt/dogs-decoder", "dogs", "json"),
+				WithEncoder(&testEncoder{extensions: []string{"json"}}),
+			},
 		},
 	}
 

--- a/internal/strs/lists.go
+++ b/internal/strs/lists.go
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2023 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+package strs
+
+// Contains returns if a string is in the list.
+func Contains(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsAll returns if all the wanted strings are in the list.
+func ContainsAll(list []string, want []string) bool {
+	m := make(map[string]int, len(list))
+
+	for _, s := range list {
+		m[s] = 1
+	}
+
+	for _, w := range want {
+		if _, ok := m[w]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// Missing returns the list of all the missing strings that were wanted but not
+// present in the list.
+func Missing(list []string, want []string) []string {
+	missing := make([]string, 0, len(want))
+
+	m := make(map[string]int, len(list))
+
+	for _, s := range list {
+		m[s] = 1
+	}
+
+	for _, w := range want {
+		if _, ok := m[w]; !ok {
+			missing = append(missing, w)
+		}
+	}
+
+	return missing
+}

--- a/internal/strs/lists_test.go
+++ b/internal/strs/lists_test.go
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2023 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+package strs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContains(t *testing.T) {
+	tests := []struct {
+		description string
+		list        []string
+		want        string
+		found       bool
+	}{
+		{
+			description: "found at the front",
+			list:        []string{"foo", "bar", "goo"},
+			want:        "foo",
+			found:       true,
+		}, {
+			description: "found in the middle",
+			list:        []string{"foo", "bar", "goo"},
+			want:        "bar",
+			found:       true,
+		}, {
+			description: "found at the end",
+			list:        []string{"foo", "bar", "goo"},
+			want:        "goo",
+			found:       true,
+		}, {
+			description: "not found",
+			list:        []string{"foo", "bar", "goo"},
+			want:        "oops",
+		}, {
+			description: "empty list",
+			list:        []string{},
+			want:        "nothing",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+
+			assert.Equal(tc.found, Contains(tc.list, tc.want))
+		})
+	}
+}
+
+func TestContainsAll(t *testing.T) {
+	tests := []struct {
+		description string
+		list        []string
+		want        []string
+		found       bool
+	}{
+		{
+			description: "found all, simple",
+			list:        []string{"foo", "bar", "goo"},
+			want:        []string{"foo"},
+			found:       true,
+		}, {
+			description: "found all",
+			list:        []string{"foo", "bar", "goo"},
+			want:        []string{"bar", "foo", "goo"},
+			found:       true,
+		}, {
+			description: "found with duplicates",
+			list:        []string{"foo", "bar", "goo"},
+			want:        []string{"goo", "bar", "goo", "goo"},
+			found:       true,
+		}, {
+			description: "not all found",
+			list:        []string{"foo", "bar", "goo"},
+			want:        []string{"foo", "oops"},
+		}, {
+			description: "empty all list",
+			list:        []string{},
+			want:        []string{"things"},
+		}, {
+			description: "empty want list",
+			list:        []string{"things"},
+			want:        []string{},
+			found:       true,
+		}, {
+			description: "empty all and want list",
+			list:        []string{},
+			want:        []string{},
+			found:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+
+			assert.Equal(tc.found, ContainsAll(tc.list, tc.want))
+		})
+	}
+}
+
+func TestMissing(t *testing.T) {
+	tests := []struct {
+		description string
+		list        []string
+		want        []string
+		missing     []string
+	}{
+		{
+			description: "found all, simple",
+			list:        []string{"foo", "bar", "goo"},
+			want:        []string{"foo"},
+		}, {
+			description: "found all",
+			list:        []string{"foo", "bar", "goo"},
+			want:        []string{"bar", "foo", "goo"},
+		}, {
+			description: "found with duplicates",
+			list:        []string{"foo", "bar", "goo"},
+			want:        []string{"goo", "bar", "goo", "goo"},
+		}, {
+			description: "not all found",
+			list:        []string{"foo", "bar", "goo"},
+			want:        []string{"foo", "oops"},
+			missing:     []string{"oops"},
+		}, {
+			description: "empty all list",
+			list:        []string{},
+			want:        []string{"things"},
+			missing:     []string{"things"},
+		}, {
+			description: "empty want list",
+			list:        []string{"things"},
+			want:        []string{},
+		}, {
+			description: "empty all and want list",
+			list:        []string{},
+			want:        []string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+
+			got := Missing(tc.list, tc.want)
+			if tc.missing == nil {
+				assert.Empty(got)
+			} else {
+				assert.Equal(tc.missing, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add hints that are checked at the end of the options collection time. This allows goschtalt to recommend encoders/decoders that may change as time goes by, but not require them directly.  Generally these will be used to make collections of Options easier to manage.