### PR TITLE
Fix issue #52 - return []byte{} for empty tree.

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -45,6 +45,12 @@ func (c *Config) Marshal(opts ...MarshalOption) ([]byte, error) {
 		tree = tree.ToRedacted()
 	}
 
+	// Issue 52 - depending on encoders, they may encode a nil or null object
+	// instead of returning an expected empty array of bytes.
+	if tree.IsEmpty() {
+		return []byte{}, nil
+	}
+
 	enc, err := c.opts.encoders.find(cfg.format)
 	if err != nil {
 		return nil, err

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/goschtalt/goschtalt/pkg/encoder"
+	"github.com/goschtalt/goschtalt/pkg/meta"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -52,6 +53,9 @@ func TestMarshal(t *testing.T) {
 			opts:        []MarshalOption{FormatAs("json"), IncludeOrigins(true)},
 			expected:    `{"Origins":[{"File":"file","Line":1,"Col":123}],"Array":null,"Map":{"foo":{"Origins":[{"File":"file","Line":2,"Col":123}],"Array":null,"Map":null,"Value":"bar"}},"Value":null}`,
 		}, {
+			description: "Import and export an empty tree.",
+			opts:        []MarshalOption{FormatAs("json"), IncludeOrigins(true)},
+		}, {
 			description: "Not compiled.",
 			input:       `{"foo":"bar"}`,
 			notCompiled: true,
@@ -80,8 +84,12 @@ func TestMarshal(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			tree, err := decode("file", tc.input).ResolveCommands()
-			require.NoError(err)
+			var tree meta.Object
+			var err error
+			if tc.input != "" {
+				tree, err = decode("file", tc.input).ResolveCommands()
+				require.NoError(err)
+			}
 
 			now := time.Time{}
 			if !tc.notCompiled {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -718,7 +718,7 @@ func (obj Object) FilterNonSerializable() Object {
 		for _, val := range obj.Array {
 			if val.isSerializable() {
 				got := val.FilterNonSerializable()
-				if !got.isEmpty() {
+				if !got.IsEmpty() {
 					array = append(array, got)
 				}
 			}
@@ -730,7 +730,7 @@ func (obj Object) FilterNonSerializable() Object {
 		for key, val := range obj.Map {
 			if val.isSerializable() {
 				got := val.FilterNonSerializable()
-				if !got.isEmpty() {
+				if !got.IsEmpty() {
 					m[key] = val.FilterNonSerializable()
 				}
 			}
@@ -792,9 +792,9 @@ func (obj Object) isSerializable() bool {
 	return true
 }
 
-// isEmpty returns if the object is an empty node.  Metadata about the node
+// IsEmpty returns if the object is an empty node.  Metadata about the node
 // like the origin or secret are ignored in this determination.
-func (o Object) isEmpty() bool {
+func (o Object) IsEmpty() bool {
 	if len(o.Array) == 0 && len(o.Map) == 0 && o.Value == nil {
 		return true
 	}


### PR DESCRIPTION
If the three is empty, return a []byte{} instead of trying to encode an empty tree value.  The different encoders can encode the empty tree differently making use harder than it should be.