### PR TITLE
fix: Correctly reference absolute files.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ permissions:
 
 jobs:
   ci:
-    uses: goschtalt/.github/.github/workflows/ci.yml@1ed9737e04eb54fe049597baf7f0ba28814a6e08 # v1.0.23
+    uses: goschtalt/.github/.github/workflows/ci.yml@63f9c131eef85332a1147460e3819694be9bf9d1 # v1.1.0
     secrets: inherit

--- a/buffer.go
+++ b/buffer.go
@@ -5,7 +5,7 @@ package goschtalt
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/goschtalt/goschtalt/internal/print"
@@ -139,7 +139,7 @@ func (b *buffer) toTree(delimiter string, u Unmarshaler, decoders *codecRegistry
 		return meta.Object{}, err
 	}
 
-	ext := strings.TrimPrefix(filepath.Ext(b.recordName), ".")
+	ext := strings.TrimPrefix(path.Ext(b.recordName), ".")
 
 	dec, err := decoders.find(ext)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goschtalt/goschtalt
 
-go 1.18
+go 1.20
 
 require (
 	github.com/goschtalt/approx v1.0.0

--- a/goschtalt.go
+++ b/goschtalt.go
@@ -4,7 +4,7 @@
 package goschtalt
 
 import (
-	"path/filepath"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -275,7 +275,7 @@ func (c *Config) OrderList(list []string) []string {
 		file := cfg.name
 
 		// Only include the file if there is a decoder for it.
-		ext := strings.TrimPrefix(filepath.Ext(file), ".")
+		ext := strings.TrimPrefix(path.Ext(file), ".")
 		_, err := c.opts.decoders.find(ext)
 		if err == nil {
 			out = append(out, file)

--- a/internal/fspath/fspath.go
+++ b/internal/fspath/fspath.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2024 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+package fspath
+
+import (
+	"errors"
+	"path"
+	"path/filepath"
+)
+
+var ErrInvalidPath = errors.New("invalid path")
+
+// IsLocal returns true if the file is a local file.
+//
+// The file must be a fs.FS formatted path with '/' as the separator.
+func IsLocal(file string) bool {
+	return filepath.IsLocal(filepath.FromSlash(file))
+}
+
+// ToRel converts a path to an absolute path for use in a fs.FS filesystem.
+// This means any volume name and leading separator are stripped off, and any
+// relative path is converted to an absolute path.
+//
+// The file must be a fs.FS formatted path with '/' as the separator.
+func ToRel(file string) (string, error) {
+	return toRel(file, filepath.Abs)
+}
+
+// MustToRel is like RelAbs but panics if there is an error.
+func MustToRel(file string) string {
+	rv, err := ToRel(file)
+	if err != nil {
+		panic(err)
+	}
+	return rv
+}
+
+// toRel provides a way to test RelToAbs with a custom getwd function.
+func toRel(file string, abs func(string) (string, error)) (string, error) {
+	if file == "" {
+		return "", ErrInvalidPath
+	}
+
+	// The simple case is if the path is already absolute.
+	if path.IsAbs(file) {
+		return path.Clean(file[1:]), nil
+	}
+
+	// The path is relative, so we need to convert it to an absolute path.
+	targetAbs, err := abs(".")
+	if err != nil {
+		return "", err
+	}
+
+	targetAbs = filepath.Join(targetAbs, file)
+
+	// Just keep going up the tree until we find the root instead of trying
+	// to figure out the way root is represented on the current system.
+	base := targetAbs
+	for {
+		up := filepath.Join(base, "..")
+		up = filepath.Clean(up)
+		if up == base {
+			base = up
+			break
+		}
+		base = up
+	}
+
+	targetRel, err := filepath.Rel(base, targetAbs)
+	if err != nil {
+		return "", err
+	}
+
+	return path.Clean(filepath.ToSlash(targetRel)), nil
+}

--- a/internal/fspath/fspath_most_test.go
+++ b/internal/fspath/fspath_most_test.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2024 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package fspath
+
+import "errors"
+
+var errUnknown = errors.New("unknown error")
+
+var toRelTests = []toRelTest{
+	{
+		description: "abs case",
+		path:        "/a/b/c",
+		abs: func(string) (string, error) {
+			return "/a/b", nil
+		},
+		want: "a/b/c",
+	}, {
+		description: "rel case",
+		path:        "../c",
+		abs: func(string) (string, error) {
+			return "/a/b", nil
+		},
+		want: "a/c",
+	}, {
+		description: "empty case",
+		path:        "",
+		abs: func(string) (string, error) {
+			return "/a/b", nil
+		},
+		expectedErr: ErrInvalidPath,
+	}, {
+		description: "error case",
+		path:        "a/b/c",
+		abs: func(string) (string, error) {
+			return "", errUnknown
+		},
+		expectedErr: errUnknown,
+	},
+}

--- a/internal/fspath/fspath_test.go
+++ b/internal/fspath/fspath_test.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2024 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+package fspath
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type toRelTest struct {
+	description string
+	path        string
+	abs         func(string) (string, error)
+	want        string
+	expectedErr error
+}
+
+func Test_toRel(t *testing.T) {
+	// Use the tests defined by the platform-specific tests.
+	for _, tc := range toRelTests {
+		t.Run(tc.description, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			got, err := toRel(tc.path, tc.abs)
+
+			if tc.expectedErr != nil {
+				assert.Empty(got)
+				assert.ErrorIs(err, tc.expectedErr)
+				return
+			}
+
+			require.NoError(err)
+			assert.Equal(tc.want, got)
+		})
+	}
+}
+
+func TestToRel(t *testing.T) {
+	assert := assert.New(t)
+
+	got, err := ToRel("./a")
+
+	assert.NotEmpty(got)
+	assert.NoError(err)
+}
+
+func TestMustToRel(t *testing.T) {
+	assert := assert.New(t)
+
+	got := MustToRel("./a")
+
+	assert.NotEmpty(got)
+}

--- a/internal/fspath/fspath_windows_test.go
+++ b/internal/fspath/fspath_windows_test.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package fspath
+
+var toRelTests = []toRelTest{
+	{
+		description: "abs case",
+		path:        "/a/b/c",
+		abs: func(string) (string, error) {
+			return "c:\\a\\b", nil
+		},
+		want: "a/b/c",
+	}, {
+		description: "rel case",
+		path:        "../c",
+		abs: func(string) (string, error) {
+			return "c:\\a\\b", nil
+		},
+		want: "a/c",
+	},
+}

--- a/internal/tests/README.md
+++ b/internal/tests/README.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2024 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Why this directory?
+
+By having this directory as a sub-directory that only imports goschtalt and is
+a subdirectory, it's possible to run a couple of end to end tests that need to
+access files that are not in the current working directory safely.  It also
+keeps circular import loops from being a problem.

--- a/internal/tests/tests_test.go
+++ b/internal/tests/tests_test.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2024 Weston Schmidt <weston_schmidt@alumni.purdue.edu>
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/goschtalt/goschtalt"
+	"github.com/goschtalt/goschtalt/internal/fspath"
+	"github.com/stretchr/testify/assert"
+)
+
+func findRoot() (string, error) {
+	root, err := filepath.Abs(".")
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		up, err := filepath.Abs(filepath.Join(root, ".."))
+		if err != nil || up == root {
+			break
+		}
+		root = up
+	}
+
+	return root, nil
+}
+
+func TestEndToEndWithPathOutsidePWD(t *testing.T) {
+	assert := assert.New(t)
+
+	root, err := findRoot()
+	assert.NoError(err)
+
+	rel := os.DirFS(".")
+	abs := os.DirFS(root)
+
+	file := "../../.golangci.yml"
+
+	wd, _ := os.Getwd()
+	fmt.Printf("Current working directory: %s\n", wd)
+	fmt.Printf("Root: %s\n", root)
+	fmt.Printf("File: %s\n", file)
+	g, err := goschtalt.New(
+		goschtalt.AddJumbledHalt(abs, rel, file),
+	)
+
+	assert.NoError(err)
+	assert.NotNil(g)
+}
+
+func TestEndToEndWithAbsPath(t *testing.T) {
+	assert := assert.New(t)
+
+	root, err := findRoot()
+	assert.NoError(err)
+
+	rel := os.DirFS(".")
+	abs := os.DirFS(root)
+
+	file := fspath.MustToRel("../../.golangci.yml")
+
+	g, err := goschtalt.New(
+		goschtalt.AddJumbledHalt(abs, rel, file),
+	)
+
+	assert.NoError(err)
+	assert.NotNil(g)
+}

--- a/options_test.go
+++ b/options_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"testing/fstest"
 
+	"github.com/goschtalt/goschtalt/internal/fspath"
 	"github.com/goschtalt/goschtalt/pkg/decoder"
 	"github.com/goschtalt/goschtalt/pkg/encoder"
 	"github.com/stretchr/testify/assert"
@@ -166,10 +167,10 @@ func TestOptions(t *testing.T) {
 				filegroups: []filegroup{
 					{
 						fs:    abs,
-						paths: []string{absFile},
+						paths: []string{fspath.MustToRel(absFile)},
 					}, {
 						fs:    rel,
-						paths: []string{"./path2"},
+						paths: []string{"path2"},
 					},
 				},
 			},


### PR DESCRIPTION
This fixes issue #76 where files outside the local working directory tree are not accessable because they either have leading `/` or volume names in the way and fs.FS can't handle them.

This also adds two tests based on the project directory structure to test that this works end to end.