### PR TITLE
feat!:Fix Expand so it can be layered.

### DIFF
--- a/options.go
+++ b/options.go
@@ -66,7 +66,8 @@ type options struct {
 	values     []record
 
 	// Expansions; there can be many.
-	expansions []expand
+	expansions    []expand
+	exapansionMax int
 
 	// Hints are special options that check that the configuration makes sense;
 	// there can be many.
@@ -966,6 +967,37 @@ func (m optionsOption) String() string {
 // StdCfgLayout doesn't support a shared windows layout today.  One is welcome.
 func StdCfgLayout(appName string, files ...string) Option {
 	return stdCfgLayout(appName, files)
+}
+
+// SetMaxExpansions provides a way to set the maximum number of expansions
+// allowed before a recursion error is returned.  The value must be greater
+// than 0.
+//
+// # Default
+//
+// The default value is 10000.
+func SetMaxExpansions(max int) Option {
+	if max < 1 {
+		return WithError(
+			fmt.Errorf("%w, SetMaxExpansions must be greater than 0", ErrInvalidInput),
+		)
+	}
+	return setMaxExpansionsOption(max)
+}
+
+type setMaxExpansionsOption int
+
+func (s setMaxExpansionsOption) apply(opts *options) error {
+	opts.exapansionMax = int(s)
+	return nil
+}
+
+func (_ setMaxExpansionsOption) ignoreDefaults() bool {
+	return false
+}
+
+func (s setMaxExpansionsOption) String() string {
+	return print.P("SetMaxExpansions", print.Int(int(s)))
 }
 
 // ---- Options related helper functions follow --------------------------------

--- a/shared_test.go
+++ b/shared_test.go
@@ -80,10 +80,10 @@ func (m mockRecordSorter) Less(a, b string) bool {
 // Mock Expander ///////////////////////////////////////////////////////////////
 
 type mockExpander struct {
-	f func(string) string
+	f func(string) (string, bool)
 }
 
-func (m mockExpander) Expand(s string) string {
+func (m mockExpander) Expand(s string) (string, bool) {
 	return m.f(s)
 }
 


### PR DESCRIPTION
BREAKING CHANGE

- Changes the Expand interface from Expand(string) string to Expand(string) (string, bool) allowing the returned value to be clear about if it is replacing the value or not.
- This change also enables better handling of multiple Expand() options.